### PR TITLE
binary array ld vocabulary

### DIFF
--- a/incubation/binary-array-ld/README.md
+++ b/incubation/binary-array-ld/README.md
@@ -1,0 +1,5 @@
+# Binary Array Linked Data - Incubation Folder
+
+This folder will hold RDF files for the draft OGC Encoding Linked Data Graphs in binary array encodings.
+
+The first OGC work programme aiming to adopt this is the NetCDF-LD Files specification.

--- a/incubation/binary-array-ld/binary-array-ld.ttl
+++ b/incubation/binary-array-ld/binary-array-ld.ttl
@@ -1,0 +1,110 @@
+@prefix cc:    <http://creativecommons.org/ns#> .
+@prefix void:  <http://rdfs.org/ns/void#> .
+@prefix org:   <http://www.w3.org/ns/org#> .
+@prefix odrs:  <http://schema.theodi.org/odrs#> .
+@prefix ssd:   <http://www.w3.org/ns/sparql-service-description#> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix version: <http://purl.org/linked-data/version#> .
+@prefix qb:    <http://purl.org/linked-data/cube#> .
+@prefix dgu:   <http://reference.data.gov.uk/def/reference/> .
+@prefix ui:    <http://purl.org/linked-data/registry-ui#> .
+@prefix dct:   <http://purl.org/dc/terms/> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix reg:   <http://purl.org/linked-data/registry#> .
+@prefix ldp:   <http://www.w3.org/ns/ldp#> .
+@prefix time:  <http://www.w3.org/2006/time#> .
+@prefix api:   <http://purl.org/linked-data/api/vocab#> .
+@prefix vann:  <http://purl.org/vocab/vann/> .
+@prefix vs:    <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix prov:  <http://www.w3.org/ns/prov#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix dc:    <http://purl.org/dc/elements/1.1/> .
+
+<https://www.opengis.net/def/binary-array-ld/isPrefixedBy>
+        a                owl:ObjectProperty ;
+        rdfs:domain      <https://www.opengis.net/def/binary-array-ld/Container> ;
+        rdfs:label       "isPrefixedBy" ;
+        rdfs:range       <https://www.opengis.net/def/binary-array-ld/Resource> ;
+        dct:description  "This Container has prefixes defined by that Resource, a list of prefix definitions." .
+
+<https://www.opengis.net/def/binary-array-ld/Array>
+        a                owl:Class ;
+        rdfs:label       "Array" ;
+        rdfs:subClassOf  <https://www.opengis.net/def/binary-array-ld/Resource> ;
+        dct:description  "A multi-dimensional array of literals." .
+
+<https://www.opengis.net/def/binary-array-ld/contains>
+        a                owl:ObjectProperty ;
+        rdfs:domain      <https://www.opengis.net/def/binary-array-ld/Container> ;
+        rdfs:label       "contains" ;
+        rdfs:range       <https://www.opengis.net/def/binary-array-ld/Resource> ;
+        dct:description  "The Container contains the Resource. " .
+
+<https://www.opengis.net/def/binary-array-ld/target>
+        a                owl:ObjectProperty ;
+        rdfs:domain      <https://www.opengis.net/def/binary-array-ld/Reference> ;
+        rdfs:label       "target" ;
+        rdfs:range       <https://www.opengis.net/def/binary-array-ld/Array> ;
+        dct:description  "The Array a Reference targets." .
+
+<https://www.opengis.net/def/binary-array-ld/Reference>
+        a                owl:Class ;
+        rdfs:label       "Reference" ;
+        rdfs:subClassOf  <https://www.opengis.net/def/binary-array-ld/Resource> ;
+        dct:description  "The definition of a reference from one Array to another." .
+
+<https://www.opengis.net/def/binary-array-ld/Resource>
+        a                owl:Class ;
+        rdfs:label       "Resource" ;
+        rdfs:subClassOf  rdfs:Resource ;
+        dct:description  "A resource being described by metadata." .
+
+<https://www.opengis.net/def/binary-array-ld/sourceRefShape>
+        a                owl:DatatypeProperty ;
+        rdfs:domain      <https://www.opengis.net/def/binary-array-ld/Reference> ;
+        rdfs:label       "source reference shape" ;
+        dct:description  "The shape of the source Array in the array reference relation. Only expected if this shape differs from the source Array's own shape." .
+
+<https://www.opengis.net/def/binary-array-ld/shape>
+        a                owl:DatatypeProperty ;
+        rdfs:domain      <https://www.opengis.net/def/binary-array-ld/Array> ;
+        rdfs:label       "shape" ;
+        dct:description  "The shape of the Array." .
+
+<https://www.opengis.net/def/binary-array-ld/references>
+        a                owl:ObjectProperty ;
+        rdfs:domain      <https://www.opengis.net/def/binary-array-ld/Array> ;
+        rdfs:label       "references" ;
+        rdfs:range       <https://www.opengis.net/def/binary-array-ld/Reference> ;
+        dct:description  "This Array references that Reference. " .
+
+<https://www.opengis.net/def/binary-array-ld/isAliasedBy>
+        a                owl:ObjectProperty ;
+        rdfs:domain      <https://www.opengis.net/def/binary-array-ld/Container> ;
+        rdfs:label       "isAliasedBy" ;
+        rdfs:range       <https://www.opengis.net/def/binary-array-ld/Resource> ;
+        dct:description  "This Container is aliased by this Resource, an alias graph." .
+
+<https://www.opengis.net/def/binary-array-ld>
+        a                      reg:Register , owl:Ontology , ldp:Container ;
+        rdfs:label             "development" ;
+        rdfs:member            <https://www.opengis.net/def/binary-array-ld/shape> , <https://www.opengis.net/def/binary-array-ld/Resource> , <https://www.opengis.net/def/binary-array-ld/contains> , <https://www.opengis.net/def/binary-array-ld/targetRefShape> , <https://www.opengis.net/def/binary-array-ld/isPrefixedBy> , <https://www.opengis.net/def/binary-array-ld/Reference> , <https://www.opengis.net/def/binary-array-ld/target> , <https://www.opengis.net/def/binary-array-ld/sourceRefShape> , <https://www.opengis.net/def/binary-array-ld/references> , <https://www.opengis.net/def/binary-array-ld/Container> , <https://www.opengis.net/def/binary-array-ld/isAliasedBy> , <https://www.opengis.net/def/binary-array-ld/Array> ;
+        dct:description        "Binary Array Linked Data Ontology" ;
+        dct:modified           "2019-12-30T14:27:55.468Z"^^xsd:dateTime ;
+        owl:versionInfo        3 ;
+        ldp:hasMemberRelation  rdfs:member .
+
+<https://www.opengis.net/def/binary-array-ld/Container>
+        a                owl:Class ;
+        rdfs:label       "Container" ;
+        rdfs:subClassOf  <https://www.opengis.net/def/binary-array-ld/Resource> ;
+        dct:description  "A Resource which may contain other Resources." .
+
+<https://www.opengis.net/def/binary-array-ld/targetRefShape>
+        a                owl:DatatypeProperty ;
+        rdfs:domain      <https://www.opengis.net/def/binary-array-ld/Reference> ;
+        rdfs:label       "target reference shape" ;
+        dct:description  "The shape of the target array in the array reference relation. Only expected if this shape differs from the target array's own shape." .

--- a/incubation/netcdf-ld/README.md
+++ b/incubation/netcdf-ld/README.md
@@ -1,3 +1,0 @@
-# NetCDF for Linked Data - Incubation Folder
-
-This folder will hold RDF files for the draft OGC Encoding Linked Data Graphs in NetCDF Classic Files specification.


### PR DESCRIPTION
This proposes the adoption of the Binary Array Linked Data vocabulary

This has been reviewed by the team working on the netCDF-LD encoding standard from the NETCDF SWG 
https://github.com/opengeospatial/netCDF-Classic-LD
and is required for that work to proceed to review and approval stages.

Interest has been indicated from the GeoTIFF and HDF domains in this activity.

Hence the proposal to keep the naming of these resources independent of encoding standards that intend to make use of them.