### PR TITLE
dcat:Dataset

### DIFF
--- a/incubation/binary-array-ld/binary-array-ld.ttl
+++ b/incubation/binary-array-ld/binary-array-ld.ttl
@@ -22,6 +22,7 @@
 @prefix prov:  <http://www.w3.org/ns/prov#> .
 @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
 @prefix dc:    <http://purl.org/dc/elements/1.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
 
 <https://www.opengis.net/def/binary-array-ld/isPrefixedBy>
         a                owl:ObjectProperty ;
@@ -90,15 +91,13 @@
 
 <https://www.opengis.net/def/binary-array-ld>
         a                      reg:Register , owl:Ontology , ldp:Container ;
-        rdfs:label             "development" ;
+        rdfs:label             "Binary Array LD" ;
         rdfs:member            <https://www.opengis.net/def/binary-array-ld/shape> , <https://www.opengis.net/def/binary-array-ld/Resource> , <https://www.opengis.net/def/binary-array-ld/contains> , <https://www.opengis.net/def/binary-array-ld/targetRefShape> , <https://www.opengis.net/def/binary-array-ld/isPrefixedBy> , <https://www.opengis.net/def/binary-array-ld/Reference> , <https://www.opengis.net/def/binary-array-ld/target> , <https://www.opengis.net/def/binary-array-ld/sourceRefShape> , <https://www.opengis.net/def/binary-array-ld/references> , <https://www.opengis.net/def/binary-array-ld/Container> , <https://www.opengis.net/def/binary-array-ld/isAliasedBy> , <https://www.opengis.net/def/binary-array-ld/Array> ;
         dct:description        "Binary Array Linked Data Ontology" ;
-        dct:modified           "2019-12-30T14:27:55.468Z"^^xsd:dateTime ;
-        owl:versionInfo        3 ;
         ldp:hasMemberRelation  rdfs:member .
 
 <https://www.opengis.net/def/binary-array-ld/Container>
-        a                owl:Class ;
+        a                owl:Class, dcat:Dataset ;
         rdfs:label       "Container" ;
         rdfs:subClassOf  <https://www.opengis.net/def/binary-array-ld/Resource> ;
         dct:description  "A Resource which may contain other Resources." .

--- a/incubation/binary-array-ld/binary-array-ld.ttl
+++ b/incubation/binary-array-ld/binary-array-ld.ttl
@@ -97,7 +97,8 @@
         ldp:hasMemberRelation  rdfs:member .
 
 <https://www.opengis.net/def/binary-array-ld/Container>
-        a                owl:Class, dcat:Dataset ;
+        a                owl:Class ;
+        rdfs:subClassOf  dcat:Dataset ;
         rdfs:label       "Container" ;
         rdfs:subClassOf  <https://www.opengis.net/def/binary-array-ld/Resource> ;
         dct:description  "A Resource which may contain other Resources." .


### PR DESCRIPTION
to address the Specification ticket
https://github.com/opengeospatial/netcdf-ld/issues/34
the addition of a type statement for 
`bald:Container`
to include the type
`dcat:Dataset`
is required.

I have also noted some statements made on the definition of
<https://www.opengis.net/def/binary-array-ld>
which leaked from the previous implementation:
`dct:modified` and `owl:versionInfo`
which should not be included in the OGC NA publishing