### PR TITLE
Update 19-008r4.ttl

### DIFF
--- a/specification-elements/defs/19-008r4.ttl
+++ b/specification-elements/defs/19-008r4.ttl
@@ -1,68 +1,20 @@
-@prefix adsm: <http://www.w3.org/ns/adms#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcmi: <https://dublincore.org/specifications/dublin-core/dcmi-terms/#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix na: <http://www.opengis.net/def/metamodel/ogc-na/> .
-@prefix ns1: <http://purl.org/linked-data/registry#> .
-@prefix ns2: <http://www.w3.org/ns/dcat#> .
 @prefix ogcdt: <http://www.opengis.net/def/doc-type/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix reg: <http://purl.org/linked-data/registry#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix spec: <http://www.opengis.net/def/ont/modspec/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://www.opengis.net/def/docs/19-008r4> a spec:Specification ;
-    dct:dateSubmitted "2019-06-05"^^xsd:date ;
-    dct:identifier "http://www.opengis.net/doc/IS/GeoTIFF/1.1" ;
-    ns1:status ns1:statusValid ;
-    na:doctype ogcdt:is ;
-    spec:authority "Open Geospatial Consortium" ;
-    spec:class <http://www.opengis.net/spec/GeoTIFF/1.1/req/CitationGeoKeys>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/Core>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoDoubleParamsTag>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyCode>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoShortParamsTag>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianLongitudeGeoKey>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey> ;
-    spec:testSuite <http://www.opengis.net/spec/GeoTIFF/1.1/csuite> ;
-    skos:notation "19-008r4"^^na:doc_no ;
-    skos:note "Approved" ;
-    skos:prefLabel "OGC GeoTIFF standard" ;
-    adsm:version "1.1" ;
-    ns2:landingPage <http://docs.opengeospatial.org/is/19-008r4/19-008r4.html> ;
-    dcmi:creator "Emmanuel Devys, Ted Habermann, Chuck Heazel, Roger Lott, Even Rouault" .
+<http://www.opengis.net/spec/docs/19-008r4-anno> a owl:Ontology .
 
-<http://www.opengis.net/spec/docs/19-008r4-anno> a owl:Ontology ;
-    owl:imports <http://purl.org/dc/terms>,
-        <http://purl.org/linked-data/registry>,
-        <http://www.opengis.net/def/doc-type>,
-        <http://www.opengis.net/def/metamodel/ogc-na>,
-        <http://www.opengis.net/def/ont/modspec>,
-        <http://www.w3.org/2000/01/rdf-schema>,
-        <http://www.w3.org/2001/XMLSchema>,
-        <http://www.w3.org/2004/02/skos/core>,
-        <http://www.w3.org/ns/adms>,
-        <http://www.w3.org/ns/dcat> .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/conf/AsciiParameters> a spec:ConformanceTest ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/conf/AsciiParameters> a spec:ConformanceTest,
+        skos:Concept ;
     spec:method "%3Cdiv%3E%3Cdiv%3EPre-conditions%3Cdiv%3E%3Cdiv%3EThe%20GeoKeyDirectory%2C%20ASCIIValues%20and%20GeoKeyOffset%20values%20have%20been%20set.%3C/div%3E%3C/div%3E%3Cdiv%20class%3D%22literalblock%22%3E%0A%3Cdiv%20class%3D%22content%22%3E%0A%3Cpre%3ELocate%20the%20Key%20Entry%20Set%20using%20the%20GeoKeyDirectory%20and%20GeoKeyOffset%20values.%3C/pre%3E%0A%3C/div%3E%0A%3C/div%3E%3Cdiv%20class%3D%22literalblock%22%3E%0A%3Cdiv%20class%3D%22content%22%3E%0A%3Cpre%3EProcess%20the%20second%20Short%20integer%20in%20the%20Key%20Entry%20Set%0A%20%20%20%20%7B%0A%20%20%20%20IF%20value%20%21%3D%2034737%20THEN%20error%20out%0A%20%20%20%20%7D%0AProcess%20the%20first%20Short%20integer%20in%20the%20Key%20Entry%20Set%0A%20%20%20%20%7B%0A%20%20%20%20Set%20GeoKey%20to%20the%20value%0A%20%20%20%20%7D%0AProcess%20the%20third%20Short%20integer%20in%20the%20Key%20Entry%20Set%0A%20%20%20%20%7B%0A%20%20%20%20Set%20KeyLength%20to%20the%20value%0A%20%20%20%20%7D%0AProcess%20the%20fourth%20Short%20integer%20in%20the%20Key%20Entry%20Set%0A%20%20%20%20%7B%0A%20%20%20%20SET%20KeyValueOffset%20to%20the%20value%0A%20%20%20%20%7D%0ASET%20KeyValueOffset%20%3D%20AsciiValues%20%2B%20KeyValueOffset%3C/pre%3E%0A%3C/div%3E%0A%3C/div%3E%3Cdiv%20class%3D%22literalblock%22%3E%0A%3Cdiv%20class%3D%22content%22%3E%0A%3Cpre%3ERead%20a%20KeyLength%20ASCII%20string%20values%20from%20the%20GeoTIFF%20file%20starting%20at%20KeyValueOffset.%0A%20%20%20%20-%20The%20individual%20strings%20are%20delimited%20by%20the%20%22%7C%22%20character.%0A%20%20%20%20-%20The%20set%20of%20ASCII%20strings%20is%20null%20terminated.%0AValidate%20the%20value%0A%20%20%20%20Locate%20the%20GeoKey%20in%20the%20following%20table%0A%20%20%20%20Verify%20that%20the%20values%20read%20satisfy%20the%20constraints%20defined%20in%20the%20associated%20Requirements%20Class.%0A%20%20%20%20Verify%20that%20any%20GeoKeys%20required%20by%20the%20associated%20Requirements%20Class%20are%20present%20in%20the%20GeoKey%20Directory.%3C/pre%3E%0A%3C/div%3E%0A%3C/div%3E"^^rdf:HTML,
         """Pre-conditions
 
@@ -166,14 +118,12 @@ The location of the GeoKey value in the file
     
     
     Read a KeyLength ASCII string values from the GeoTIFF file starting at KeyValueOffset.
-        - The individual strings are delimited by the "|" character.
+        - The individual strings are delimited by the | character.
         - The set of ASCII strings is null terminated.
     Validate the value
         Locate the GeoKey in the following table
         Verify that the values read satisfy the constraints defined in the associated Requirements Class.
-        Verify that any GeoKeys required by the associated Requirements Class are present in the GeoKey Directory.
-
-""" ;
+        Verify that any GeoKeys required by the associated Requirements Class are present in the GeoKey Directory.""" ;
     spec:purpose "Verify ASCII parameters" ;
     spec:requirement <http://www.opengis.net/spec/GeoTIFF/1.1/req/CitationGeoKeys>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.ID>,
@@ -183,9 +133,11 @@ The location of the GeoKey value in the file
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntryTIFFTagLocation>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntryValueOffset> ;
     spec:testType spec:Basic ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Core> ;
     skos:prefLabel "ASCII Parameters Test" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/conf/DoubleParameters> a spec:ConformanceTest ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/conf/DoubleParameters> a spec:ConformanceTest,
+        skos:Concept ;
     spec:method "%3Cdiv%3E%3Cdiv%3EPre-conditions%3Cdiv%3E%3Cdiv%3EThe%20GeoKeyDirectory%2C%20DoubleValues%20and%20GeoKeyOffset%20values%20have%20been%20set.%3C/div%3E%3C/div%3E%3Cdiv%20class%3D%22literalblock%22%3E%0A%3Cdiv%20class%3D%22content%22%3E%0A%3Cpre%3ELocate%20the%20Key%20Entry%20Set%20using%20the%20GeoKeyDirectory%20and%20GeoKeyOffset%20values.%3C/pre%3E%0A%3C/div%3E%0A%3C/div%3E%3Cdiv%20class%3D%22literalblock%22%3E%0A%3Cdiv%20class%3D%22content%22%3E%0A%3Cpre%3EProcess%20the%20second%20Short%20integer%20in%20the%20Key%20Entry%20Set%0A%20%20%20%20%7B%0A%20%20%20%20IF%20value%20%21%3D%2034736%20THEN%20error%20out%0A%20%20%20%20%7D%0AProcess%20the%20first%20Short%20integer%20in%20the%20Key%20Entry%20Set%0A%20%20%20%20%7B%0A%20%20%20%20Set%20GeoKey%20to%20the%20value%0A%20%20%20%20%7D%0AProcess%20the%20third%20Short%20integer%20in%20the%20Key%20Entry%20Set%0A%20%20%20%20%7B%0A%20%20%20%20Set%20KeyLength%20to%20the%20value%0A%20%20%20%20%7D%0AProcess%20the%20fourth%20Short%20integer%20in%20the%20Key%20Entry%20Set%0A%20%20%20%20%7B%0A%20%20%20%20SET%20KeyValueOffset%20to%20the%20value%0A%20%20%20%20%7D%0ASET%20KeyValueOffset%20%3D%20DoubleValues%20%2B%20%28KeyValueOffset%20%2A%208%29%3C/pre%3E%0A%3C/div%3E%0A%3C/div%3E%3Cdiv%20class%3D%22literalblock%22%3E%0A%3Cdiv%20class%3D%22content%22%3E%0A%3Cpre%3ERead%20a%20KeyLength%20Double%20values%20from%20the%20GeoTIFF%20file%20starting%20at%20KeyValueOffset.%0AValidate%20the%20value%0A%20%20%20%20Locate%20the%20GeoKey%20in%20the%20following%20table%0A%20%20%20%20Verify%20that%20the%20values%20read%20satisfy%20the%20constraints%20defined%20in%20the%20associated%20Requirements%20Class.%0A%20%20%20%20Verify%20that%20any%20GeoKeys%20required%20by%20the%20associated%20Requirements%20Class%20are%20present%20in%20the%20GeoKey%20Directory.%3C/pre%3E%0A%3C/div%3E%0A%3C/div%3E%3Cdiv%20class%3D%22paragraph%22%3E%0A%3Cp%3EDouble%20GeoKey%20Tests%3C/p%3E%0A%3C/div%3E"^^rdf:HTML,
         """Pre-conditions
 
@@ -294,9 +246,7 @@ The location of the GeoKey value in the file
         Verify that the values read satisfy the constraints defined in the associated Requirements Class.
         Verify that any GeoKeys required by the associated Requirements Class are present in the GeoKey Directory.
 
-Double GeoKey Tests
-
-""" ;
+Double GeoKey Tests""" ;
     spec:purpose "Verify Double parameters" ;
     spec:requirement <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidInvFlatteningGeoKey>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey>,
@@ -314,9 +264,11 @@ Double GeoKey Tests
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjScalarParameterGeoKey>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey> ;
     spec:testType spec:Basic ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Core> ;
     skos:prefLabel "Double Parameters Test" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/conf/GeoKeyDirectory> a spec:ConformanceTest ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/conf/GeoKeyDirectory> a spec:ConformanceTest,
+        skos:Concept ;
     spec:method "%3Cdiv%3E%3Cdiv%3EPre-conditions%3Cdiv%3E%3Cdiv%3EA%20GeoKey%20Directory%20has%20been%20located%3C/div%3E%3C/div%3E%3Cdiv%20class%3D%22olist%20arabic%22%3E%0A%3Col%20class%3D%22arabic%22%3E%0A%3Cli%3E%0A%3Cp%3EValidate%20and%20process%20the%20GeoKey%20Directory%20Header%3C/p%3E%0A%3Cdiv%20class%3D%22ulist%22%3E%0A%3Cul%3E%0A%3Cli%3E%0A%3Cp%3EVerify%20that%20Bytes%200-1%20%3D%201%20%28Key%20Directory%20Version%29.%3C/p%3E%0A%3C/li%3E%0A%3Cli%3E%0A%3Cp%3EVerify%20that%20Bytes%202-3%20%3D%201%20%28Key%20Revision%29%3C/p%3E%0A%3C/li%3E%0A%3Cli%3E%0A%3Cp%3EVerify%20that%20Bytes%204-5%20%3D%200%20or%201%20%28Key%20Minor%20Revision%29%3C/p%3E%0A%3C/li%3E%0A%3Cli%3E%0A%3Cp%3EBytes%206-7%20contain%20the%20number%20of%20Key%20Entry%20Sets%20in%20this%20directory.%20Set%20KeySetCount%20to%20this%20value.%3C/p%3E%0A%3C/li%3E%0A%3C/ul%3E%0A%3C/div%3E%0A%3C/li%3E%0A%3Cli%3E%0A%3Cp%3EProcess%20each%20Key%20Entry%20Set%20using%20the%20following%20pseudocode%3A%3C/p%3E%0A%3Cdiv%20class%3D%22literalblock%22%3E%0A%3Cdiv%20class%3D%22content%22%3E%0A%3Cpre%3ESET%20GeoKeyOffset%20%3D%208%0AWHILE%20KeySetCount%20is%20not%200%0A%20%20%20%7B%0A%20%20%20Verify%20that%20the%20GeoKey%20%28first%20Short%20integer%29%20is%20greater%20than%20the%20previous%20GeoKey.%0A%20%20%20Process%20the%20second%20Short%20integer%20in%20the%20Key%20Entry%20Set%0A%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20IF%20value%20%3D%200%20THEN%20Execute%20test%20http%3A//www.opengis.net/spec/GeoTIFF/1.1/conf/Short_Param%20passing%20GeoKeyOffset%20as%20a%20parameter%0A%20%20%20%20%20%20%20IF%20value%20%3D%2034735%20THEN%20Execute%20test%20http%3A//www.opengis.net/spec/GeoTIFF/1.1/conf/Short_Param%20passing%20GeoKeyOffset%20as%20a%20parameter%0A%20%20%20%20%20%20%20IF%20value%20%3D%2034736%20THEN%20Execute%20test%20http%3A//www.opengis.net/spec/GeoTIFF/1.1/conf/Double_Param%20passing%20GeoKeyOffset%20as%20a%20parameter%0A%20%20%20%20%20%20%20IF%20value%20%3D%2034737%20THEN%20%20Execute%20test%20http%3A//www.opengis.net/spec/GeoTIFF/1.1/conf/ASCII_Param%20passing%20GeoKeyOffset%20as%20a%20parameter%0A%20%20%20%20%20%20%20%7D%0A%20%20%20SET%20GeoKeyOffset%20%3D%20GeoKeyOffset%20%2B%208%0A%20%20%20KeySetCount%20%3D%20KeySetCount%20-%201%0A%20%20%20%7D%3C/pre%3E%0A%3C/div%3E%0A%3C/div%3E%0A%3C/li%3E%0A%3Cli%3E%0A%3Cp%3EValidate%20that%20the%20number%20of%20Key%20Sets%20processed%20equal%20the%20number%20specified%20in%20the%20header.%3C/p%3E%0A%3C/li%3E%0A%3C/ol%3E%0A%3C/div%3E"^^rdf:HTML,
         """Pre-conditions
 
@@ -423,9 +375,7 @@ The number of entries in the GeoKey directory
        KeySetCount = KeySetCount - 1
        }
 
-  3. Validate that the number of Key Sets processed equal the number specified in the header.
-
-""" ;
+  3. Validate that the number of Key Sets processed equal the number specified in the header.""" ;
     spec:purpose "Verify the GeoKey Directory" ;
     spec:requirement <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyDirectoryVersion>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyDirectoryVersionValue>,
@@ -440,15 +390,11 @@ The number of entries in the GeoKey directory
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.numberOfKeys>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeySort> ;
     spec:testType spec:Basic ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Core> ;
     skos:prefLabel "GeoKey Directory Test" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey> a spec:ConformanceClass ;
-    spec:conformanceTest <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey/ModelPixelScaleTag>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey/ModelTiepointTag>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey/ModelTransformationTag> ;
-    skos:prefLabel "Conformance Class Raster2Model_CoordinateTransformation_GeoKey" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey/ModelPixelScaleTag> a spec:ConformanceTest ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey/ModelPixelScaleTag> a spec:ConformanceTest,
+        skos:Concept ;
     spec:method "%3Cdiv%3E%3Cdiv%3EPre-conditions%3Cdiv%3E%3Cdiv%3EThe%20TagLength%20and%20TagValue%20values%20have%20been%20set.%3C/div%3E%3C/div%3E%3Cdiv%20class%3D%22literalblock%22%3E%0A%3Cdiv%20class%3D%22content%22%3E%0A%3Cpre%3EVerify%20that%20the%20TagLength%20is%20three%20%283%29%3C/pre%3E%0A%3C/div%3E%0A%3C/div%3E%3Cdiv%20class%3D%22literalblock%22%3E%0A%3Cdiv%20class%3D%22content%22%3E%0A%3Cpre%3ERead%20three%20double%20values%20from%20the%20GeoTIFF%20file%20starting%20at%20TagValue.%3C/pre%3E%0A%3C/div%3E%0A%3C/div%3E"^^rdf:HTML,
         """Pre-conditions
 
@@ -492,16 +438,16 @@ Location of the value of a TIFF tag in the GeoTIFF file
     Verify that the TagLength is three (3)
     
     
-    Read three double values from the GeoTIFF file starting at TagValue.
-
-""" ;
+    Read three double values from the GeoTIFF file starting at TagValue.""" ;
     spec:purpose "Verify the contents of the ModelPixelScaleTag parameter" ;
     spec:requirement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.axisReversal>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.standardConvention> ;
     spec:testType spec:Basic ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey> ;
     skos:prefLabel "ModelPixelScaleTag Test" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey/ModelTiepointTag> a spec:ConformanceTest ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey/ModelTiepointTag> a spec:ConformanceTest,
+        skos:Concept ;
     spec:method "%3Cdiv%3E%3Cdiv%3EPre-conditions%3Cdiv%3E%3Cdiv%3EThe%20TagLength%20and%20TagValue%20values%20have%20been%20set.%3C/div%3E%3C/div%3E%3Cdiv%20class%3D%22literalblock%22%3E%0A%3Cdiv%20class%3D%22content%22%3E%0A%3Cpre%3EVerify%20that%20the%20TagLength%20is%20six%20%286%29%3C/pre%3E%0A%3C/div%3E%0A%3C/div%3E%3Cdiv%20class%3D%22literalblock%22%3E%0A%3Cdiv%20class%3D%22content%22%3E%0A%3Cpre%3ERead%20six%20double%20values%20from%20the%20GeoTIFF%20file%20starting%20at%20TagValue.%3C/pre%3E%0A%3C/div%3E%0A%3C/div%3E"^^rdf:HTML,
         """Pre-conditions
 
@@ -545,15 +491,15 @@ Location of the value of a TIFF tag in the GeoTIFF file
     Verify that the TagLength is six (6)
     
     
-    Read six double values from the GeoTIFF file starting at TagValue.
-
-""" ;
+    Read six double values from the GeoTIFF file starting at TagValue.""" ;
     spec:purpose "Verify the contents of the ModelTiepointTag parameter" ;
     spec:requirement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag.count> ;
     spec:testType spec:Basic ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey> ;
     skos:prefLabel "ModelTiepointTag Test" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey/ModelTransformationTag> a spec:ConformanceTest ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey/ModelTransformationTag> a spec:ConformanceTest,
+        skos:Concept ;
     spec:method "%3Cdiv%3E%3Cdiv%3EPre-conditions%3Cdiv%3E%3Cdiv%3EThe%20TagLength%20and%20TagValue%20values%20have%20been%20set.%3C/div%3E%3C/div%3E%3Cdiv%20class%3D%22literalblock%22%3E%0A%3Cdiv%20class%3D%22content%22%3E%0A%3Cpre%3EVerify%20that%20the%20TagLength%20is%20sixteen%20%2816%29%3C/pre%3E%0A%3C/div%3E%0A%3C/div%3E%3Cdiv%20class%3D%22literalblock%22%3E%0A%3Cdiv%20class%3D%22content%22%3E%0A%3Cpre%3ERead%20sixteen%20double%20values%20from%20the%20GeoTIFF%20file%20starting%20at%20TagValue.%3C/pre%3E%0A%3C/div%3E%0A%3C/div%3E"^^rdf:HTML,
         """Pre-conditions
 
@@ -597,15 +543,15 @@ Location of the value of a TIFF tag in the GeoTIFF file
     Verify that the TagLength is sixteen (16)
     
     
-    Read sixteen double values from the GeoTIFF file starting at TagValue.
-
-""" ;
+    Read sixteen double values from the GeoTIFF file starting at TagValue.""" ;
     spec:purpose "Verify the contents of the ModelTransformationTag parameter" ;
     spec:requirement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag.count> ;
     spec:testType spec:Basic ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey> ;
     skos:prefLabel "ModelTransformationTag Test" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/conf/ShortParameters> a spec:ConformanceTest ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/conf/ShortParameters> a spec:ConformanceTest,
+        skos:Concept ;
     spec:method "%3Cdiv%3E%3Cdiv%3EPre-conditions%3Cdiv%3E%3Cdiv%3EThe%20GeoKeyDirectory%20and%20GeoKeyOffset%20values%20have%20been%20set%3C/div%3E%3C/div%3E%3Cdiv%20class%3D%22literalblock%22%3E%0A%3Cdiv%20class%3D%22content%22%3E%0A%3Cpre%3ELocate%20the%20Key%20Entry%20Set%20using%20the%20GeoKeyDirectory%20and%20GeoKeyOffset%20values.%3C/pre%3E%0A%3C/div%3E%0A%3C/div%3E%3Cdiv%20class%3D%22literalblock%22%3E%0A%3Cdiv%20class%3D%22content%22%3E%0A%3Cpre%3EProcess%20the%20second%20Short%20integer%20in%20the%20Key%20Entry%20Set%0A%20%20%20%20%7B%0A%20%20%20%20IF%20value%20%21%3D%200%20OR%2034735%20THEN%20error%20out%0A%20%20%20%20%7D%0AProcess%20the%20first%20Short%20integer%20in%20the%20Key%20Entry%20Set%0A%20%20%20%20%7B%0A%20%20%20%20SET%20GeoKey%20to%20the%20value%0A%20%20%20%20%7D%0AProcess%20the%20third%20Short%20integer%20in%20the%20Key%20Entry%20Set%0A%20%20%20%20%7B%0A%20%20%20%20SET%20KeyLength%20to%20the%20value%0A%20%20%20%20%7D%0AIF%20KeyLength%20%3D%201%20THEN%0A%20%20%20%20SET%20KeyValueOffset%20%3D%20GeoKeyDirectory%20%2B%20GeoKeyOffset%20%2B%206%0AELSE%0A%20%20%20%20%7B%0A%20%20%20%20Process%20the%20fourth%20Short%20integer%20in%20the%20Key%20Entry%20Set%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20SET%20KeyValueOffset%20to%20the%20value%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20SET%20KeyValueOffset%20%3D%20GeoKeyDirectory%20%2B%20%28KeyValueOffset%20%2A%202%29%0A%20%20%20%20%7D%3C/pre%3E%0A%3C/div%3E%0A%3C/div%3E%3Cdiv%20class%3D%22literalblock%22%3E%0A%3Cdiv%20class%3D%22content%22%3E%0A%3Cpre%3ERead%20a%20KeyLength%20Short%20values%20from%20the%20GeoTIFF%20file%20starting%20at%20KeyValueOffset.%0AValidate%20the%20value%0A%20%20%20%20Locate%20the%20GeoKey%20in%20the%20following%20table%0A%20%20%20%20Verify%20that%20the%20values%20read%20satisfy%20the%20constraints%20defined%20in%20the%20associated%20Requirements%20Class.%0A%20%20%20%20Verify%20that%20any%20GeoKeys%20required%20by%20the%20associated%20Requirements%20Class%20are%20present%20in%20the%20GeoKey%20Directory.%3C/pre%3E%0A%3C/div%3E%0A%3C/div%3E"^^rdf:HTML,
         """Pre-conditions
 
@@ -707,9 +653,7 @@ The location of the GeoKey value in the file
     Validate the value
         Locate the GeoKey in the following table
         Verify that the values read satisfy the constraints defined in the associated Requirements Class.
-        Verify that any GeoKeys required by the associated Requirements Class are present in the GeoKey Directory.
-
-""" ;
+        Verify that any GeoKeys required by the associated Requirements Class are present in the GeoKey Directory.""" ;
     spec:purpose "Verify Short parameters" ;
     spec:requirement <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey>,
@@ -730,9 +674,11 @@ The location of the GeoKey value in the file
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey> ;
     spec:testType spec:Basic ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Core> ;
     skos:prefLabel "Short Parameters Test" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/conf/TIFF.Tags> a spec:ConformanceTest ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/conf/TIFF.Tags> a spec:ConformanceTest,
+        skos:Concept ;
     spec:method "%3Cdiv%20class%3D%22paragraph%22%3E%0A%3Cp%3EValidate%20and%20process%20the%20TIFF%20header%3C/p%3E%0A%3C/div%3E%3Cdiv%20class%3D%22ulist%22%3E%0A%3Cul%3E%0A%3Cli%3E%0A%3Cp%3EVerify%20that%20Bytes%200-1%20%3D%200X4949%20%28%22II%22%20%3D%20little%20endian%29%20or%200X4D4D%20%28%22MM%22%20%3D%20big%20endian%29.%3C/p%3E%0A%3C/li%3E%0A%3Cli%3E%0A%3Cp%3EVerify%20that%20Bytes%202-3%20%3D%20the%20short%20integer%20value%2042%20interpreted%20using%20the%20byte%20order%20specified%20in%20bytes%200-1.%3C/p%3E%0A%3C/li%3E%0A%3Cli%3E%0A%3Cp%3EBytes%204-7%20are%20the%20offset%20to%20the%20first%20Image%20File%20Directory.%20Save%20this%20value%20as%20IFD_Offset.%3C/p%3E%0A%3C/li%3E%0A%3C/ul%3E%0A%3C/div%3E%3Cdiv%20class%3D%22paragraph%22%3E%0A%3Cp%3EProcess%20each%20IFD%20using%20the%20following%20pseudocode%3A%3C/p%3E%0A%3C/div%3E%3Cdiv%20class%3D%22literalblock%22%3E%0A%3Cdiv%20class%3D%22content%22%3E%0A%3Cpre%3EWHILE%20IFD_Offset%20is%20not%200%2C%20process%20this%20IFD%0A%20%20%20%7B%0A%20%20%20Bytes%200-1%20contain%20the%20number%20of%20IFD%20entries%20in%20this%20IFD.%0A%20%20%20DO%20FOR%20each%20IFD%20entry%20%28processed%20in%20sequence%29%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20Bytes%200-1%20contain%20the%20TIFF%20tag%20value.%0A%20%20%20%20%20%20Verify%20that%20the%20new%20tag%20value%20is%20greater%20than%20the%20previous%20tag%20value.%0A%20%20%20%20%20%20IF%20value%20%3D%2034735%20THEN%0A%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20Validate%20that%20Bytes%202-3%20%3D%203%20%28Short%20Integer%29%0A%20%20%20%20%20%20%20%20%20%20Validate%20that%20Bytes%204-7%20represent%20an%20Integer%20value%20greater%20than%20or%20equal%20to%204%0A%20%20%20%20%20%20%20%20%20%20Set%20GeoKeyDirectory%20to%20the%20value%20in%20Bytes%208-11%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20IF%20value%20%3D%2034736%20THEN%0A%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20Validate%20that%20Bytes%202-3%20%3D%2012%20%28Double%29%0A%20%20%20%20%20%20%20%20%20%20Set%20DoubleValues%20to%20the%20value%20in%20Bytes%208-11%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20IF%20value%20%3D%2034737%20THEN%0A%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20Validate%20that%20Bytes%202-3%20%3D%202%20%28ASCII%29%0A%20%20%20%20%20%20%20%20%20%20Set%20ASCIIValues%20to%20the%20value%20in%20Bytes%208-11%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20IF%20value%20%3D%2033550%20%28ModelPixelScaleTag%29%20THEN%0A%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20Set%20PixelScaleTag%20to%20the%20location%20of%20this%20IFD%20entry%20in%20the%20GeoTIFF%20file%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20IF%20value%20%3D%2033922%20%28ModelTiepointTag%29%20THEN%0A%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20Set%20TiepointTag%20to%20the%20location%20of%20this%20IFD%20entry%20in%20the%20GeoTIFF%20file%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20IF%20value%20%3D%2034264%20%28ModelTransformationTag%29%20THEN%0A%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20Set%20TransformTag%20to%20the%20location%20of%20this%20IFD%20entry%20in%20the%20GeoTIFF%20file%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20IF%20GeoKeyDirectory%20has%20been%20set%20THEN%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20execute%20test%20http%3A//www.opengis.net/spec/GeoTIFF/1.1/conf/GeoKeyDirectory%0A%20%20%20%20%20%20Validate%20that%20there%20is%20a%20GTModelType%20GeoKey%20in%20the%20GeoKey%20Directory%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20ELSE%20Throw%20an%20error.%0A%20%20IF%20PixelScaleTag%20has%20been%20set%20THEN%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20Validate%20that%20Bytes%202-3%20%3D%2012%20%28Double%29%0A%20%20%20%20%20%20Set%20TagLength%20to%20the%20value%20in%20Bytes%204-7%0A%20%20%20%20%20%20Set%20TagValue%20to%20the%20value%20in%20Bytes%208-11%0A%20%20%20%20%20%20Validate%20that%20this%20IFD%20contains%20a%20ModelTiepointTag%0A%20%20%20%20%20%20Execute%20test%20http%3A//www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey/ModelPixelScaleTag%0A%20%20%20%20%20%20%7D%0A%20%20IF%20TiepointTag%20has%20been%20set%20THEN%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20Validate%20that%20Bytes%202-3%20%3D%2012%20%28Double%29%0A%20%20%20%20%20%20Set%20TagLength%20to%20the%20value%20in%20Bytes%204-7%0A%20%20%20%20%20%20Set%20TagValue%20to%20the%20value%20in%20Bytes%208-11%0A%20%20%20%20%20%20Execute%20test%20http%3A//www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey/ModelTiepointTag%0A%20%20%20%20%20%20%7D%0A%20%20IF%20TransformTag%20has%20been%20set%20THEN%0A%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20Validate%20that%20Bytes%202-3%20%3D%2012%20%28Double%29%0A%20%20%20%20%20%20Set%20TagLength%20to%20the%20value%20in%20Bytes%204-7%0A%20%20%20%20%20%20Set%20TagValue%20to%20the%20value%20in%20Bytes%208-1%0A%20%20%20%20%20%20Validate%20that%20this%20IFD%20does%20not%20contain%20a%20ModelPixelScaleTag%0A%20%20%20%20%20%20Execute%20test%20http%3A//www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey/ModelTransformationTag%0A%20%20%20%20%20%20%7D%0A%20%20Validate%20that%20this%20IFD%20contains%20either%20a%20ModelTransformationTag%20or%20a%20ModelTiepointTag.%0A%20%20IFD_Offset%20%3D%20the%20last%20four%20bytes%20of%20the%20current%20IFD%0A%20%20%7D%3C/pre%3E%0A%3C/div%3E%0A%3C/div%3E"^^rdf:HTML,
         """Text Variables
 
@@ -840,7 +786,7 @@ Location of the value of a TIFF tag in the GeoTIFF file
   
 Validate and process the TIFF header
 
-  * Verify that Bytes 0-1 = 0X4949 ("II" = little endian) or 0X4D4D ("MM" = big endian).
+  * Verify that Bytes 0-1 = 0X4949 (II = little endian) or 0X4D4D (MM = big endian).
 
   * Verify that Bytes 2-3 = the short integer value 42 interpreted using the byte order specified in bytes 0-1.
 
@@ -917,9 +863,7 @@ Process each IFD using the following pseudocode:
           }
       Validate that this IFD contains either a ModelTransformationTag or a ModelTiepointTag.
       IFD_Offset = the last four bytes of the current IFD
-      }
-
-""" ;
+      }""" ;
     spec:purpose "Verify the TIFF header and prepare for processing the GeoTIFF tags." ;
     spec:requirement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ByteOrder>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/DataGeoTags>,
@@ -939,137 +883,175 @@ Process each IFD using the following pseudocode:
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/TIFF>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/TagSort> ;
     spec:testType spec:Basic ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Core> ;
     skos:prefLabel "TIFF Tags Test" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/csuite> a spec:ConformanceSuite ;
-    spec:class <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Core>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey> .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/CitationGeoKeys.ID> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/CitationGeoKeys.ID> a spec:Requirement,
+        skos:Concept ;
     dct:description """The GTCitationGeoKey SHALL have ID = 1026The GeodeticCitationGeoKey SHALL have
 ID = 2049The ProjectedCitationGeoKey SHALL have ID = 3073The
 VerticalCitationGeoKey SHALL have ID = 4097""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/CitationGeoKeys> ;
     skos:prefLabel "Requirement 15.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/CitationGeoKeys.type> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/CitationGeoKeys.type> a spec:Requirement,
+        skos:Concept ;
     dct:description "The CitationGeoKeys SHALL have type = ASCII" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/CitationGeoKeys> ;
     skos:prefLabel "Requirement 15.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/Core> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ByteOrder>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/DataGeoTags>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/DataTypes>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeySort>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/TIFF>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/TagSort> ;
-    skos:definition "A GeoTIFF file is a valid TIFF 6.0 file." ;
-    skos:prefLabel "Requirements Class TIFF" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey.EPSG> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey.EPSG> a spec:Requirement,
+        skos:Concept ;
     dct:description """EllipsoidGeoKey values in the range 1024-32766 SHALL be EPSG ellipsoid
 CodesNOTE: In GeoTIFF v1.0 the range was 7000-7999. Several values in this
 range have been deprecated or deleted from the EPSG Dataset and should no
 longer be used. See""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey> ;
     skos:prefLabel "Requirement 21.4" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey.ID> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey.ID> a spec:Requirement,
+        skos:Concept ;
     dct:description "The EllipsoidGeoKey SHALL have ID = 2056" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey> ;
     skos:prefLabel "Requirement 21.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey.private> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey.private> a spec:Requirement,
+        skos:Concept ;
     dct:description "EllipsoidGeoKey values in the range 32768-65535 SHALL be private" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey> ;
     skos:prefLabel "Requirement 21.6" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey.reserved> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey.reserved> a spec:Requirement,
+        skos:Concept ;
     dct:description "EllipsoidGeoKey values in the range 1-1023 SHALL be reserved" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey> ;
     skos:prefLabel "Requirement 21.3" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey.type> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey.type> a spec:Requirement,
+        skos:Concept ;
     dct:description "The EllipsoidGeoKey SHALL have type = SHORT" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey> ;
     skos:prefLabel "Requirement 21.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey.user-defined> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey.user-defined> a spec:Requirement,
+        skos:Concept ;
     dct:description """If the EllipsoidGeoKey value is 32767 (User-Defined) then the GTCitationGeoKey
 and the EllipsoidSemiMajorAxisGeoKey SHALL be populated together with the one
 of either the EllipsoidSemiMinorAxisGeoKey or the
 EllipsoidInvFlatteningGeoKey.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey> ;
     skos:prefLabel "Requirement 21.5" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidInvFlatteningGeoKey.ID> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidInvFlatteningGeoKey.ID> a spec:Requirement,
+        skos:Concept ;
     dct:description "The EllipsoidInvFlatteningGeoKey SHALL have ID = 2059" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey> ;
     skos:prefLabel "Requirement 24.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidInvFlatteningGeoKey.type> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidInvFlatteningGeoKey.type> a spec:Requirement,
+        skos:Concept ;
     dct:description "The EllipsoidInvFlatteningGeoKey SHALL have type = DOUBLE" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey> ;
     skos:prefLabel "Requirement 24.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey.ID> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey.ID> a spec:Requirement,
+        skos:Concept ;
     dct:description "The EllipsoidSemiMajorAxisGeoKey SHALL have ID = 2057" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey> ;
     skos:prefLabel "Requirement 22.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey.type> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey.type> a spec:Requirement,
+        skos:Concept ;
     dct:description "The EllipsoidSemiMajorAxisGeoKey SHALL have type = DOUBLE" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey> ;
     skos:prefLabel "Requirement 22.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey.units> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey.units> a spec:Requirement,
+        skos:Concept ;
     dct:description """The units of the EllipsoidSemiMajorAxisGeoKey SHALL be defined by the value of
 GeogLinearUnitsGeoKey""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey> ;
     skos:prefLabel "Requirement 22.3" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMinorAxisGeoKey.ID> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMinorAxisGeoKey.ID> a spec:Requirement,
+        skos:Concept ;
     dct:description "The EllipsoidSemiMinorAxisGeoKey SHALL have ID = 2058" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey> ;
     skos:prefLabel "Requirement 23.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMinorAxisGeoKey.type> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMinorAxisGeoKey.type> a spec:Requirement,
+        skos:Concept ;
     dct:description "The EllipsoidSemiMinorAxisGeoKey SHALL have type = DOUBLE" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey> ;
     skos:prefLabel "Requirement 23.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMinorAxisGeoKey.units> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMinorAxisGeoKey.units> a spec:Requirement,
+        skos:Concept ;
     dct:description """The units of the EllipsoidSemiMinorAxisGeoKey SHALL be defined by the value of
 GeogLinearUnitsGeoKey""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey> ;
     skos:prefLabel "Requirement 23.3" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.ID> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.ID> a spec:Requirement,
+        skos:Concept ;
     dct:description "The GTModelTypeGeoKey SHALL have ID = 1024" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey> ;
     skos:prefLabel "Requirement 8.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.geocenCRS> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.geocenCRS> a spec:Requirement,
+        skos:Concept ;
     dct:description """If the GTModelTypeGeoKey value is 3 (Model CRS is a geocentric CRS) then the
 GeoTIFF file SHALL include a GeodeticCRSGeoKey.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey> ;
     skos:prefLabel "Requirement 8.9" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.geogCRS> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.geogCRS> a spec:Requirement,
+        skos:Concept ;
     dct:description """If the GTModelTypeGeoKey value is 2 (Model CRS is a geographic 2D CRS) then
 the GeoTIFF file SHALL include a GeodeticCRSGeoKey.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey> ;
     skos:prefLabel "Requirement 8.8" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.private> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.private> a spec:Requirement,
+        skos:Concept ;
     dct:description "GTModelTypeGeoKey values in the range 32768-65535 SHALL be private" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey> ;
     skos:prefLabel "Requirement 8.6" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.projCRS> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.projCRS> a spec:Requirement,
+        skos:Concept ;
     dct:description """If the GTModelTypeGeoKey value is 1 (Model CRS is a projected 2D CRS) then the
 GeoTIFF file SHALL include a ProjectedCRSGeoKey.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey> ;
     skos:prefLabel "Requirement 8.7" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.required> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.required> a spec:Requirement,
+        skos:Concept ;
     dct:description "A GeoTIFF file SHALL include a GTModelTypeGeoKey" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey> ;
     skos:prefLabel "Requirement 8.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.reserved> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.reserved> a spec:Requirement,
+        skos:Concept ;
     dct:description "GTModelTypeGeoKey values in the range 4-32766 SHALL be reserved" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey> ;
     skos:prefLabel "Requirement 8.5" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.type> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.type> a spec:Requirement,
+        skos:Concept ;
     dct:description "The GTModelTypeGeoKey SHALL have type = SHORT" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey> ;
     skos:prefLabel "Requirement 8.3" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.userdefined> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.userdefined> a spec:Requirement,
+        skos:Concept ;
     dct:description """If the GTModelTypeGeoKey value is 32767 (user-defined) then the
 GTCitationGeoKey SHALL be populated.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey> ;
     skos:prefLabel "Requirement 8.10" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.value> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.value> a spec:Requirement,
+        skos:Concept ;
     dct:description """The GTModelTypeGeoKey value SHALL be:* 0 to indicate that the Model CRS in
 undefined or unknown; or* 1 to indicate that the Model CRS is a 2D projected
 coordinate reference system, indicated by the value of the ProjectedCRSGeoKey;
@@ -1078,534 +1060,845 @@ system, indicated by the value of the GeodeticCRSGeoKey; or* 3 to indicate
 that the Model CRS is a geocentric Cartesian 3D coordinate reference system,
 indicated by the value of the GeodeticCRSGeoKey; or* 32767 to indicate that
 the Model CRS type is user-defined.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey> ;
     skos:prefLabel "Requirement 8.4" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.ID> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.ID> a spec:Requirement,
+        skos:Concept ;
     dct:description "The GTRasterTypeGeoKey SHALL have ID = 1025" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey> ;
     skos:prefLabel "Requirement 7.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.private> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.private> a spec:Requirement,
+        skos:Concept ;
     dct:description "GTRasterTypeGeoKey values in the range 32768-65535 SHALL be private" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey> ;
     skos:prefLabel "Requirement 7.5" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.reserved> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.reserved> a spec:Requirement,
+        skos:Concept ;
     dct:description "GTRasterTypeGeoKey values in the range 3-32766 SHALL be reserved" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey> ;
     skos:prefLabel "Requirement 7.4" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.type> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.type> a spec:Requirement,
+        skos:Concept ;
     dct:description "The GTRasterTypeGeoKey SHALL have type = SHORT" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey> ;
     skos:prefLabel "Requirement 7.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.value> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.value> a spec:Requirement,
+        skos:Concept ;
     dct:description """The GTRasterTypeGeoKey value SHALL be:* 0 to indicate that the Raster type is
 undefined or unknown; or* 1 to indicate that the Raster type is PixelIsArea;
 or* 2 to indicate that the Raster type is PixelIsPoint; or* 32767 to indicate
 that the Raster type is user-defined.Recommendation: the use of 0 (undefined)
 or 32767 (user-defined) is not recommended""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey> ;
     skos:prefLabel "Requirement 7.3" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.ID>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.NULLWrite>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.count>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.terminator>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.type> ;
-    skos:definition """The following requirements govern the storage of parameter values when the values are of type ASCII. All text values in a TIFF file must be null-terminated ASCII.
-
-Example of a GeoAscii tag containing only one string: "NAD27 / UTM zone 11N|{NULL}" (where {NULL} is the ASCII character of code 0)
-
-Example of a GeoAscii tag containing two strings: \"NAD27 / UTM zone 11N|NAD27|{NULL}\"""" ;
-    skos:prefLabel "Requirements Class GeoAsciiParamsTag" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.NULLWrite> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.NULLWrite> a spec:Requirement,
+        skos:Concept ;
     dct:description """NULL (ASCII code = 0) characters SHALL not be present in the string content
 written in the GeoAsciiParamsTagNOTE: this requirement only applies for the
 content of the tag. The TIFF specification requires that the last byte of a
 TIFF tag of type ASCII is NULL.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag> ;
     skos:prefLabel "Requirement 6.4" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.terminator> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.terminator> a spec:Requirement,
+        skos:Concept ;
     dct:description """The pipe character | in the GeoAsciiParamsTag SHALL be used as the character
 to terminate a string written in as ASCII tagNOTE: If multiple strings are
 written in the same tag, this terminator character also serves as a
 separator.NOTE: This requirement only applies for the content of the tag. The
 TIFF specification requires that the last byte of a TIFF tag of type ASCII is
 NULL.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag> ;
     skos:prefLabel "Requirement 6.3" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoDoubleParamsTag> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoDoubleParamsTag.ID>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoDoubleParamsTag.count> ;
-    skos:definition "The following requirements govern the storage of parameter values when the values are of type Double." ;
-    skos:prefLabel "Requirements Class GeoDoubleParamsTag" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyCode> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyCode.undefined>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyCode.userDefined> ;
-    skos:definition """For consistency, several key codes have the same meaning in all implemented GeoKeys
-
-The "undefined" code means that this parameter is intentionally omitted or unknown.
-
-In some cases, additional GeoKeys are required when the "User-Defined" value is used. Those requirements are included within a Requirements Class, where appropriate.""" ;
-    skos:prefLabel "Requirements Class GeoKeyCode" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyCode.undefined> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyCode.undefined> a spec:Requirement,
+        skos:Concept ;
     dct:description "GeoKeys with a value of 0 SHALL indicate intentionally omitted parameters" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyCode> ;
     skos:prefLabel "Requirement 3.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyCode.userDefined> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyCode.userDefined> a spec:Requirement,
+        skos:Concept ;
     dct:description "GeoKeys with a value of 32767 SHALL indicate user-defined parameters" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyCode> ;
     skos:prefLabel "Requirement 3.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.ID>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.count>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyDirectoryVersion>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyDirectoryVersionValue>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntry>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntryKeyCount>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntryKeyID>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntrySetCount>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntryTIFFTagLocation>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntryValueOffset>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyRevision>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyRevisionValue>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.minorRevision>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.minorRevisionValue>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.numberOfKeys>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.type> ;
-    skos:definition """The GeoKeyDirectoryTag Requirements Class specifies the requirements for implementing the reserved GeoKeyDirectoryTag TIFF tag.
-
-A GeoTIFF file stores projection parameters in a set of "Keys" which are virtually identical in function to a TIFF tag, but have one more level of abstraction above TIFF. Like a tag, a Key has an ID number ranging from 0 to 65535, but unlike TIFF tags, all key ID's are available for use in GeoTIFF parameter definitions.
-
-The Keys in GeoTIFF (also called "GeoKeys") are all referenced from the GeoKeyDirectoryTag tag. The first four keys form the GeoKey Directory Header. The keys which make up this header are: KeyDirectoryVersion, KeyRevision, MinorRevision, and NumberOfKeys.
-
-The GeoKey Directory Header is followed by <NumberOfKeys> Key Entries. Each Key Entry consists of four values.
-
-
-
-"KeyID" gives the key-ID value of the Key (identical in function to TIFF tag ID, but completely independent of TIFF tag-space).
-
-
-"TIFFTagLocation" indicates which TIFF tag contains the value(s) of the Key: if TIFFTagLocation is 0, then the value is SHORT, and is contained in the "ValueOffset" entry. Otherwise, the type (format) of the value is implied by the TIFF-Type of the tag containing the value.
-
-
-"Count" indicates the number of values in this key.
-
-
-"ValueOffset" ValueOffset indicates the index- offset into the TagArray indicated by TIFFTagLocation, if it is nonzero. If TIFFTagLocation=0, then ValueOffset contains the actual (SHORT) value of the Key, and Count=1 is implied. Note that the offset is not a byte-offset, but rather an index based on the natural data type of the specified tag array.""" ;
-    skos:prefLabel "Requirements Class GeoKeyDirectoryTag" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoShortParamsTag> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoShortParamsTag.Criteria>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoShortParamsTag.Location> ;
-    skos:definition "The following requirements govern the storage of parameter values when there are two or more values of type Short." ;
-    skos:prefLabel "Requirements Class GeoShortParamsTag" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoShortParamsTag.Criteria> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoShortParamsTag.Criteria> a spec:Requirement,
+        skos:Concept ;
     dct:description """In the case where a Parameter of type Short has more than one value, those
 values SHALL be stored in the GeoKeysDirectory""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoShortParamsTag> ;
     skos:prefLabel "Requirement 4.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoShortParamsTag.Location> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoShortParamsTag.Location> a spec:Requirement,
+        skos:Concept ;
     dct:description """Parameter values stored in the GeoKeysDirectory SHALL appear after the last
 Key Entry""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoShortParamsTag> ;
     skos:prefLabel "Requirement 4.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.EPSG> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.EPSG> a spec:Requirement,
+        skos:Concept ;
     dct:description """GeodeticCRSGeoKey values in the range 1024-32766 SHALL be EPSG geographic 2D
 or geocentric CRS codesNOTE: In GeoTIFF v1.0 the range was 4000-4999. Several
 values in this range have been deprecated or deleted from the EPSG Dataset and
 should no longer be used. See""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey> ;
     skos:prefLabel "Requirement 13.4" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.ID> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.ID> a spec:Requirement,
+        skos:Concept ;
     dct:description "The GeodeticCRSGeoKey SHALL have ID = 2048" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey> ;
     skos:prefLabel "Requirement 13.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.private> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.private> a spec:Requirement,
+        skos:Concept ;
     dct:description "GeodeticCRSGeoKey values in the range 32768-65535 SHALL be private" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey> ;
     skos:prefLabel "Requirement 13.6" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.reserved> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.reserved> a spec:Requirement,
+        skos:Concept ;
     dct:description """GeodeticCRSGeoKey values in the range 1-1023 SHALL be reserved.NOTE: In
 GeoTIFF v1.0 the reserved ranges were 1001-3999 and 5000-32766.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey> ;
     skos:prefLabel "Requirement 13.3" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.type> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.type> a spec:Requirement,
+        skos:Concept ;
     dct:description "The GeodeticCRSGeoKey SHALL have type = SHORT" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey> ;
     skos:prefLabel "Requirement 13.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.user-defined> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.user-defined> a spec:Requirement,
+        skos:Concept ;
     dct:description """If the GeodeticCRSGeoKey value is 32767 (User-Defined) then the
 GeodeticCitationGeoKey, GeodeticDatumGeoKey and at least one of
 GeogAngularUnitsGeoKey or GeogLinearUnitsGeoKey SHALL be populated.NOTE: if
 the user-defined CRS is geographic 2D, GeogAngularUnitsGeoKey should be
 populated ; if the user-defined CRS is geocentric, GeogLinearUnitsGeoKey
 should be populated.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey> ;
     skos:prefLabel "Requirement 13.5" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.EPSG> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.EPSG> a spec:Requirement,
+        skos:Concept ;
     dct:description """GeodeticDatumGeoKey values in the range 1024-32766 SHALL be EPSG geodetic
 datum codes.NOTE: In GeoTIFF v1.0 the range was 6000-6999. Several values in
 this range have been deprecated or deleted from the EPSG Dataset and should no
 longer be used. See""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey> ;
     skos:prefLabel "Requirement 18.4" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.ID> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.ID> a spec:Requirement,
+        skos:Concept ;
     dct:description "The GeodeticDatumGeoKey SHALL have ID = 2050" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey> ;
     skos:prefLabel "Requirement 18.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.private> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.private> a spec:Requirement,
+        skos:Concept ;
     dct:description "GeodeticDatumGeoKey values in the range 32768-65535 SHALL be private" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey> ;
     skos:prefLabel "Requirement 18.6" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.reserved> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.reserved> a spec:Requirement,
+        skos:Concept ;
     dct:description """GeodeticDatumGeoKey values in the range 1-1023 SHALL be reserved.NOTE: In
 GeoTIFF v1.0 the reserved ranges were 1001-5999 and 7000-32766.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey> ;
     skos:prefLabel "Requirement 18.3" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.type> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.type> a spec:Requirement,
+        skos:Concept ;
     dct:description "The GeodeticDatumGeoKey SHALL have type = SHORT" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey> ;
     skos:prefLabel "Requirement 18.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.userdefined> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.userdefined> a spec:Requirement,
+        skos:Concept ;
     dct:description """If the GeodeticDatumGeoKey value is 32767 (User-Defined) then the
 GeodeticCitationGeoKey, PrimeMeridianGeoKey and EllipsoidGeoKey SHALL be
 populated.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey> ;
     skos:prefLabel "Requirement 18.5" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.ID>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.axisReversal>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.count>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.standardConvention>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.type> ;
-    skos:definition "" ;
-    skos:prefLabel "Requirements Class ModelPixelScaleTag" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.count> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.count> a spec:Requirement,
+        skos:Concept ;
     dct:description """The ModelPixelScaleTag SHALL have 3 values representing the scale factor in
 the X, Y, and Z directions""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag> ;
     skos:prefLabel "Requirement 10.3" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag.ID>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag.count>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag.type> ;
-    skos:definition "" ;
-    skos:prefLabel "Requirements Class ModelTiepointTag" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag.ID>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag.count>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag.type> ;
-    skos:definition "" ;
-    skos:prefLabel "Requirements Class ModelTransformationTag" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.EPSG> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.EPSG> a spec:Requirement,
+        skos:Concept ;
     dct:description """PrimeMeridianGeoKey values in the range 1024-32766 SHALL be EPSG Prime
 Meridian CodesNOTE: In GeoTIFF v1.0 the range was 8000-8999""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey> ;
     skos:prefLabel "Requirement 19.4" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.ID> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.ID> a spec:Requirement,
+        skos:Concept ;
     dct:description "The PrimeMeridianGeoKey SHALL have ID = 2051" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey> ;
     skos:prefLabel "Requirement 19.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.private> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.private> a spec:Requirement,
+        skos:Concept ;
     dct:description "PrimeMeridianGeoKey values in the range 32768-65535 SHALL be private" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey> ;
     skos:prefLabel "Requirement 19.6" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.reserved> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.reserved> a spec:Requirement,
+        skos:Concept ;
     dct:description """PrimeMeridianGeoKey values in the range 1-1023 SHALL be reservedNOTE: In
 GeoTIFF v1.0 the range was 101-7999 and 9000-32766""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey> ;
     skos:prefLabel "Requirement 19.3" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.type> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.type> a spec:Requirement,
+        skos:Concept ;
     dct:description "The PrimeMeridianGeoKey SHALL have type = SHORT" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey> ;
     skos:prefLabel "Requirement 19.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.userdefined> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.userdefined> a spec:Requirement,
+        skos:Concept ;
     dct:description """If the PrimeMeridianGeoKey value is 32767 (User-Defined) then the
 GeodeticCitationGeoKey, and PrimeMeridianLongGeoKey SHALL be populated""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey> ;
     skos:prefLabel "Requirement 19.5" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianLongitudeGeoKey.ID> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianLongitudeGeoKey.ID> a spec:Requirement,
+        skos:Concept ;
     dct:description "The PrimeMeridianLongitudeGeoKey SHALL have ID = 2061" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianLongitudeGeoKey> ;
     skos:prefLabel "Requirement 20.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianLongitudeGeoKey.type> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianLongitudeGeoKey.type> a spec:Requirement,
+        skos:Concept ;
     dct:description "The PrimeMeridianLongitudeGeoKey SHALL have type = DOUBLE" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianLongitudeGeoKey> ;
     skos:prefLabel "Requirement 20.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianLongitudeGeoKey.units> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianLongitudeGeoKey.units> a spec:Requirement,
+        skos:Concept ;
     dct:description "The unit for the PrimeMeridianLongitudeGeoKey value SHALL be GeogAngularUnits" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianLongitudeGeoKey> ;
     skos:prefLabel "Requirement 20.3" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.ID> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.ID> a spec:Requirement,
+        skos:Concept ;
     dct:description "The ProjMethodGeoKey SHALL have ID = 3075" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey> ;
     skos:prefLabel "Requirement 27.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.private> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.private> a spec:Requirement,
+        skos:Concept ;
     dct:description "ProjMethodGeoKey values in the range 32768-65535 SHALL be private" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey> ;
     skos:prefLabel "Requirement 27.6" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.reserved> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.reserved> a spec:Requirement,
+        skos:Concept ;
     dct:description "ProjMethodGeoKey values in the range 28-32766 SHALL be reserved" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey> ;
     skos:prefLabel "Requirement 27.4" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.transform> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.transform> a spec:Requirement,
+        skos:Concept ;
     dct:description """ProjMethodGeoKey values in the range 1-27 SHALL be GeoTIFF map projection
 method codesNOTE: See Annex C""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey> ;
     skos:prefLabel "Requirement 27.3" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.type> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.type> a spec:Requirement,
+        skos:Concept ;
     dct:description "The ProjMethodGeoKey SHALL have type = SHORT" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey> ;
     skos:prefLabel "Requirement 27.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.userdefined> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.userdefined> a spec:Requirement,
+        skos:Concept ;
     dct:description """If the ProjectionMethodGeoKey value is 32767 (User-Defined) then the
 ProjectedCitationGeoKey and keys for each map projection parameter (coordinate
 operation parameter) appropriate to that method SHALL be populated.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey> ;
     skos:prefLabel "Requirement 27.5" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.EPSG> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.EPSG> a spec:Requirement,
+        skos:Concept ;
     dct:description """ProjectedCRSGeoKey values in the range 1024-32766 SHALL be EPSG Projected CRS
 CodesNOTE: In GeoTIFF v1.0 the range was 20000-32760. Several values in this
 range have been deprecated or deleted from the EPSG Dataset and should no
 longer be used. See""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey> ;
     skos:prefLabel "Requirement 12.4" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.ID> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.ID> a spec:Requirement,
+        skos:Concept ;
     dct:description "The ProjectedCRSGeoKey SHALL have ID = 3072" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey> ;
     skos:prefLabel "Requirement 12.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.private> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.private> a spec:Requirement,
+        skos:Concept ;
     dct:description "ProjectedCRSGeoKey values in the range 32768-65535 SHALL be private" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey> ;
     skos:prefLabel "Requirement 12.6" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.reserved> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.reserved> a spec:Requirement,
+        skos:Concept ;
     dct:description "ProjectedCRSGeoKey values in the range 1-1023 SHALL be reserved." ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey> ;
     skos:prefLabel "Requirement 12.3" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.type> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.type> a spec:Requirement,
+        skos:Concept ;
     dct:description "The ProjectedCRSGeoKey SHALL have type = SHORT" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey> ;
     skos:prefLabel "Requirement 12.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.userdefined> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.userdefined> a spec:Requirement,
+        skos:Concept ;
     dct:description """A ProjectedCRSGeoKey value of 32767 SHALL be a user-defined projected CRS. If
 the ProjectedCRSGeoKey value is 32767 (User-Defined) then the
 ProjectedCitationGeoKey, GeodeticCRSGeoKey and ProjectionGeoKey SHALL be
 populated.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey> ;
     skos:prefLabel "Requirement 12.5" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.EPSG> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.EPSG> a spec:Requirement,
+        skos:Concept ;
     dct:description """ProjectionGeoKey values in the range 1024-32766 SHALL be valid EPSG map
 projection (coordinate operation) codesNOTE: In GeoTIFF v1.0 the range was
 10000-19999. Several values in this range have been deprecated or deleted from
 the EPSG Dataset. See""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey> ;
     skos:prefLabel "Requirement 26.4" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.ID> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.ID> a spec:Requirement,
+        skos:Concept ;
     dct:description "The ProjectionGeoKey SHALL have ID = 3074" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey> ;
     skos:prefLabel "Requirement 26.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.private> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.private> a spec:Requirement,
+        skos:Concept ;
     dct:description "ProjectionGeoKey values in the range 32768-65535 SHALL be private" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey> ;
     skos:prefLabel "Requirement 26.6" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.reserved> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.reserved> a spec:Requirement,
+        skos:Concept ;
     dct:description "ProjectionGeoKey values in the range 1-1023 SHALL be reserved" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey> ;
     skos:prefLabel "Requirement 26.3" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.type> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.type> a spec:Requirement,
+        skos:Concept ;
     dct:description "The ProjectionGeoKey SHALL have type = SHORT" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey> ;
     skos:prefLabel "Requirement 26.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.userdefined> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.userdefined> a spec:Requirement,
+        skos:Concept ;
     dct:description """If the ProjectionGeoKey value is 32767 (User-Defined) then the
 ProjectedCitationGeoKey, ProjectionMethodGeoKey, and ProjLinearUnitsGeoKey
 SHALL be populated""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey> ;
     skos:prefLabel "Requirement 26.5" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey.ID> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey.ID> a spec:Requirement,
+        skos:Concept ;
     dct:description """The GeogAngularUnitSizeGeoKey SHALL have ID = 2055The GeogLinearUnitSizeGeoKey
 SHALL have ID = 2053The ProjLinearUnitSizeGeoKey SHALL have ID = 3077""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey> ;
     skos:prefLabel "Requirement 17.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey.type> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey.type> a spec:Requirement,
+        skos:Concept ;
     dct:description """The GeogAngularUnitSizeGeoKey, GeogLinearUnitSizeGeoKey and
 ProjLinearUnitSizeGeoKey SHALL each have type = DOUBLE""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey> ;
     skos:prefLabel "Requirement 17.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey.units> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey.units> a spec:Requirement,
+        skos:Concept ;
     dct:description """The units of the GeogAngularUnitSizeGeoKey value SHALL be radians.The units of
 the GeogLinearUnitSizeGeoKey value SHALL be meters.The units of the
 ProjLinearUnitSizeGeoKey value SHALL be meters.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey> ;
     skos:prefLabel "Requirement 17.3" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.ID> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.ID> a spec:Requirement,
+        skos:Concept ;
     dct:description """The GeogAngularUnitsGeoKey SHALL have ID = 2054The GeogAzimuthUnitsGeoKey
 SHALL have ID = 2060The GeogLinearUnitsGeoKey SHALL have ID = 2052The
 ProjLinearUnitsGeoKey SHALL have ID = 3076The VerticalUnitsGeoKey SHALL have
 ID = 4099""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey> ;
     skos:prefLabel "Requirement 16.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.angular> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.angular> a spec:Requirement,
+        skos:Concept ;
     dct:description """GeogAngularUnitsGeoKey and GeogAzimuthUnitsGeoKey values in the range
 1024-32766 SHALL be EPSG Unit Of Measure (UOM) codes with type = angle.NOTE:
 In GeoTIFF v1.0 the range was 9100-9199""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey> ;
     skos:prefLabel "Requirement 16.4" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.linear> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.linear> a spec:Requirement,
+        skos:Concept ;
     dct:description """GeogLinearUnitsGeoKey, ProjLinearUnitsGeoKey and VerticalUnitsGeoKey values in
 the range 1024-32766 SHALL be EPSG Unit Of Measure (UOM) codes with type =
 length.NOTE: In GeoTIFF v1.0 the range was 9000-9099. Several values in this
 range have been deprecated or deleted from the EPSG Dataset and should no
 longer be used. See""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey> ;
     skos:prefLabel "Requirement 16.5" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.private> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.private> a spec:Requirement,
+        skos:Concept ;
     dct:description """GeogAngularUnitsGeoKey, GeogAzimuthUnitsGeoKey, GeogLinearUnitsGeoKey,
 ProjLinearUnitsGeoKey and VerticalUnitsGeoKey values in the range 32768-65535
 SHALL be private.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey> ;
     skos:prefLabel "Requirement 16.10" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.reserved> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.reserved> a spec:Requirement,
+        skos:Concept ;
     dct:description """GeogAngularUnitsGeoKey, GeogAzimuthUnitsGeoKey, GeogLinearUnitsGeoKey,
 ProjLinearUnitsGeoKey and VerticalUnitsGeoKey values in the range 1-1023 SHALL
 be reserved.NOTE: In GeoTIFF v1.0 the range 0001-2000 was used for obsolete
 GeoTIFF codes.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey> ;
     skos:prefLabel "Requirement 16.3" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.type> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.type> a spec:Requirement,
+        skos:Concept ;
     dct:description """The GeogAngularUnitsGeoKey, the GeogAzimuthUnitsGeoKey, the
 GeogLinearUnitsGeoKey, the ProjLinearUnitsGeoKey and the VerticalUnitsGeoKey
 SHALL each have type = SHORT""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey> ;
     skos:prefLabel "Requirement 16.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.userdefinedAngular> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.userdefinedAngular> a spec:Requirement,
+        skos:Concept ;
     dct:description """A GeogAngularUnitsGeoKey or a GeogAzimuthUnitsGeoKey value of 32767 SHALL be a
 user-defined angular unit. If the value is 32767 (User-Defined) then the
 GeodeticCitationGeoKey and the GeogAngularUnitSizeGeoKey SHALL be populated""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey> ;
     skos:prefLabel "Requirement 16.6" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.userdefinedGeogLinear> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.userdefinedGeogLinear> a spec:Requirement,
+        skos:Concept ;
     dct:description """A GeogLinearUnitsGeoKey value of 32767 SHALL be a user-defined linear unit. If
 the value is 32767 (User-Defined) then the GeodeticCitationGeoKey and the
 GeogLinearUnitSizeGeoKey SHALL be populated""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey> ;
     skos:prefLabel "Requirement 16.7" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.userdefinedProjLinear> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.userdefinedProjLinear> a spec:Requirement,
+        skos:Concept ;
     dct:description """A ProjLinearUnitsGeoKey value of 32767 SHALL be a user-defined linear unit. If
 the value is 32767 (User-Defined) then the ProjectedCitationGeoKey and the
 ProjLinearUnitSizeGeoKey SHALL be populated.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey> ;
     skos:prefLabel "Requirement 16.8" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.userdefinedVertical> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.userdefinedVertical> a spec:Requirement,
+        skos:Concept ;
     dct:description """A VerticalUnitsGeoKey value of 32767 (user defined) SHALL not be usedNOTE: The
 rationale for this is that it would require a VerticalUnitSizeGeoKey, which
 does not exist in GeoTIFF 1.0. For vertical units, this document supports only
 EPSG linear units.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey> ;
     skos:prefLabel "Requirement 16.9" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.EPSG> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.EPSG> a spec:Requirement,
+        skos:Concept ;
     dct:description """VerticalDatumGeoKey values in the range 1024-32766 SHALL be EPSG vertical
 datum codesNOTE: In GeoTIFF v1.0 the range was given as 1-16383 but without
 reference to EPSG.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey> ;
     skos:prefLabel "Requirement 25.4" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.ID> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.ID> a spec:Requirement,
+        skos:Concept ;
     dct:description "The VerticalDatumGeoKey SHALL have ID = 4098" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey> ;
     skos:prefLabel "Requirement 25.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.private> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.private> a spec:Requirement,
+        skos:Concept ;
     dct:description "VerticalDatumGeoKey values in the range 32768-65535 SHALL be private" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey> ;
     skos:prefLabel "Requirement 25.6" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.reserved> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.reserved> a spec:Requirement,
+        skos:Concept ;
     dct:description """VerticalDatumGeoKey values in the range 1-1023 SHALL be reservedNOTE: In
 GeoTIFF v1.0 the reserved range was 16384-32766.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey> ;
     skos:prefLabel "Requirement 25.3" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.type> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.type> a spec:Requirement,
+        skos:Concept ;
     dct:description "The VerticalDatumGeoKey SHALL have type = SHORT" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey> ;
     skos:prefLabel "Requirement 25.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.userdefined> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.userdefined> a spec:Requirement,
+        skos:Concept ;
     dct:description """If the VerticalDatumGeoKey value is 32767 (User-Defined) then the
 VerticalCitationGeoKey SHALL be populated.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey> ;
     skos:prefLabel "Requirement 25.5" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.EPSG> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.EPSG> a spec:Requirement,
+        skos:Concept ;
     dct:description """VerticalGeoKey values in the range 1024-32766 SHALL be either EPSG Vertical
 CRS Codes or EPSG geographic 3D CRS codesNOTE: In GeoTIFF v1.0 the ranges were
 5000-5099 and 5200-5999. As at 2018-05-29 no EPSG vertical CRSs have been or
 are in this range. Values in this range have been and are used as EPSG
 vertical datum codes; in this document their use as codes for vertical CRSs is
 deprecated.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey> ;
     skos:prefLabel "Requirement 14.4" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.ID> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.ID> a spec:Requirement,
+        skos:Concept ;
     dct:description "The VerticalGeoKey SHALL have ID = 4096" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey> ;
     skos:prefLabel "Requirement 14.1" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.reserved> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.reserved> a spec:Requirement,
+        skos:Concept ;
     dct:description """VerticalGeoKey values in the range 1-1023 SHALL be reservedNOTE: In GeoTIFF
 v1.0 the reserved ranges were 0001-4999 and 6000-32766.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey> ;
     skos:prefLabel "Requirement 14.3" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.type> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.type> a spec:Requirement,
+        skos:Concept ;
     dct:description "The VerticalGeoKey SHALL have type = SHORT" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey> ;
     skos:prefLabel "Requirement 14.2" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.userdefined> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.userdefined> a spec:Requirement,
+        skos:Concept ;
     dct:description """If the VerticalGeoKey value is 32767 (User-Defined) then the
 VerticalCitationGeoKey, the VerticalUnitsGeoKey and VerticalDatumGeoKey SHALL
 be populated.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey> ;
     skos:prefLabel "Requirement 14.5" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/reqVerticalGeoKey.private> a spec:Requirement ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/reqVerticalGeoKey.private> a spec:Requirement,
+        skos:Concept ;
     dct:description "VerticalGeoKey values in the range 32768-65535 SHALL be private" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey> ;
     skos:prefLabel "Requirement 14.6" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/conf/Core> a spec:ConformanceClass,
-        spec:ConformanceTest ;
-    spec:conformanceTest <http://www.opengis.net/spec/GeoTIFF/1.1/conf/AsciiParameters>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Core>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/conf/DoubleParameters>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/conf/GeoKeyDirectory>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/conf/ShortParameters>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/conf/TIFF.Tags> ;
-    spec:method "%3Cdiv%20class%3D%22paragraph%22%3E%0A%3Cp%3EThere%20is%20no%20authoritative%20conformance%20test%20for%20TIFF%206.0.%0A2%20basic%20tests%20may%20be%20done%20on%20TIFF%20header%20%284%20first%20bytes%29%2C%20called%20TIFF%20magic%3A%0A%E2%80%A2%20Bytes%200-1%20%28byte%20order%20within%20the%20file%29%20%3D%200X4949%20%28%22II%22%20%3D%20little%20endian%29%20or%200X4D4D%20%28%22MM%22%20%3D%20big%20endian%29.%0A%E2%80%A2%20Bytes%202-3%20%3D%20the%20short%20integer%20value%2042%20interpreted%20using%20the%20byte%20order%20specified%20in%20bytes%200-1.%3C/p%3E%0A%3C/div%3E%3Cdiv%20class%3D%22paragraph%22%3E%0A%3Cp%3EThe%20best%20that%20can%20be%20achieved%20is%20to%20use%20a%20TIFF%20reference%20implementation%20to%20successfully%20read%20a%20GeoTIFF%20file.%20The%20OGC%20recommends%20the%20use%20of%20tiffdump%20based%20on%20the%20open%20source%20LibTIFF%20library%20%28%3Ca%20href%3D%22https%3A//gitlab.com/libtiff/libtiff%22%20class%3D%22bare%22%3Ehttps%3A//gitlab.com/libtiff/libtiff%3C/a%3E%29%20for%20dumping%20the%20content%20of%20TIFF%20tags%20%28displaying%20error%20messages%20if%20any%29%2C%20or%20opensource%20TIFF%20file%20validator%20%28such%20as%20the%20JHOVE%20tool%2C%20opensource%20developed%20in%20Java%20-%20cf.%20%3Ca%20href%3D%22http%3A//jhove.openpreservation.org/%22%20class%3D%22bare%22%3Ehttp%3A//jhove.openpreservation.org/%3C/a%3E%29.%3C/p%3E%0A%3C/div%3E%3Cdiv%20class%3D%22paragraph%22%3E%0A%3Cp%3EOnce%20TIFF%206.0%20conformance%20has%20been%20validated%2C%20execute%20test%20%3Ca%20href%3D%22http%3A//www.opengis.net/spec/GeoTIFF/1.1/conf/TIFF.Tags%22%20class%3D%22bare%22%3Ehttp%3A//www.opengis.net/spec/GeoTIFF/1.1/conf/TIFF.Tags%3C/a%3E.%3C/p%3E%0A%3C/div%3E"^^rdf:HTML,
-        """There is no authoritative conformance test for TIFF 6.0. 2 basic tests may be
-done on TIFF header (4 first bytes), called TIFF magic:  Bytes 0-1 (byte
-order within the file) = 0X4949 ("II" = little endian) or 0X4D4D ("MM" = big
-endian).  Bytes 2-3 = the short integer value 42 interpreted using the byte
-order specified in bytes 0-1.
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/DataGeoTags> a spec:Requirement,
+        skos:Concept ;
+    dct:description """GeoTIFF files SHALL encode all GeoTIFF specific information using the
+following specified reserved TIFF tags \\- 34735 GeoKeyDirectoryTag (mandatory)
+\\- 34736 GeoDoubleParamsTag (optional) \\- 34737 GeoAsciiParamsTag (optional)
+\\- 33550 ModelPixelScaleTag (optional) \\- 33922 ModelTiepointTag (conditional)
+\\- 34264 ModelTransformationTag (conditional) The conditional tags shall
+follow the following rules: \\- One of ModelTiepointTag or
+ModelTransformationTag SHALL be included in an Image File Directory (IFD) \\-
+If the ModelTransformationTag is included in an IFD, then a ModelPixelScaleTag
+SHALL NOT be included \\- If the ModelPixelScaleTag is included in an IFD, then
+a ModelTiepointTag SHALL also be included.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/Core> ;
+    skos:prefLabel "Requirement 1.2" .
 
-The best that can be achieved is to use a TIFF reference implementation to
-successfully read a GeoTIFF file. The OGC recommends the use of tiffdump based
-on the open source LibTIFF library (<https://gitlab.com/libtiff/libtiff>) for
-dumping the content of TIFF tags (displaying error messages if any), or
-opensource TIFF file validator (such as the JHOVE tool, opensource developed
-in Java - cf. <http://jhove.openpreservation.org/>).
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/DataTypes> a spec:Requirement,
+        skos:Concept ;
+    dct:description """GeoTIFF implementation software SHALL support all documented TIFF 6.0 tag
+data-types, and in particular ASCII, SHORT and the IEEE double-precision
+floating point DOUBLE types""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/Core> ;
+    skos:prefLabel "Requirement 1.3" .
 
-Once TIFF 6.0 conformance has been validated, execute test
-<http://www.opengis.net/spec/GeoTIFF/1.1/conf/TIFF.Tags>.
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.count> a spec:Requirement,
+        skos:Concept ;
+    dct:description """The GeoAsciiParamsTag SHALL contain the values of the key parameters of type =
+ASCII referenced by the GeoKeyDirectoryTag. If there is no key parameters of
+type = ASCII, it SHALL not be present""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag> ;
+    skos:prefLabel "Requirement 6.2" .
 
-""" ;
-    spec:purpose "Verify that the GeoTIFF file conforms to the TIFF specification." ;
-    spec:requirement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ByteOrder>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/DataTypes>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/TIFF> ;
-    spec:testType spec:Basic ;
-    skos:prefLabel "Conformance Class TIFF",
-        "TIFF Core Test" .
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.type> a spec:Requirement,
+        skos:Concept ;
+    dct:description "The GeoAsciiParamsTag SHALL have type = ASCII" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag> ;
+    skos:prefLabel "Requirement 6.5" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/CitationGeoKeys> a spec:RequirementClass ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.ID> a spec:Requirement,
+        skos:Concept ;
+    dct:description "The GeoKeyDirectoryTag SHALL have ID = 34735" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag> ;
+    skos:prefLabel "Requirement 2.1" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.count> a spec:Requirement,
+        skos:Concept ;
+    dct:description """The GeoKeyDirectoryTag SHALL include at least 4 keys (short integers) as
+header information""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag> ;
+    skos:prefLabel "Requirement 2.3" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyDirectoryVersion> a spec:Requirement,
+        skos:Concept ;
+    dct:description """The first unsigned short integer in the GeoKeyDirectoryTag SHALL hold the
+KeyDirectoryVersion.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag> ;
+    skos:prefLabel "Requirement 2.4" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyDirectoryVersionValue> a spec:Requirement,
+        skos:Concept ;
+    dct:description "The value of KeyDirectoryVersion SHALL be 1." ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag> ;
+    skos:prefLabel "Requirement 2.5" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntry> a spec:Requirement,
+        skos:Concept ;
+    dct:description """Each Key Entry in the Key Entry Set SHALL include 4 unsigned short integer
+values""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag> ;
+    skos:prefLabel "Requirement 2.12" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntryKeyID> a spec:Requirement,
+        skos:Concept ;
+    dct:description """The first unsigned short integer in the Key Entry SHALL hold the key
+identifier.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag> ;
+    skos:prefLabel "Requirement 2.13" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntrySetCount> a spec:Requirement,
+        skos:Concept ;
+    dct:description """The GeoKeyDirectoryTag SHALL hold NumberOfKeys KeyEntry Sets in addition to
+the header information""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag> ;
+    skos:prefLabel "Requirement 2.11" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyRevision> a spec:Requirement,
+        skos:Concept ;
+    dct:description """The second unsigned short integer in the GeoKeyDirectoryTag SHALL hold the
+KeyRevision.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag> ;
+    skos:prefLabel "Requirement 2.6" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyRevisionValue> a spec:Requirement,
+        skos:Concept ;
+    dct:description "The value of KeyRevision SHALL be 1." ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag> ;
+    skos:prefLabel "Requirement 2.7" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.minorRevision> a spec:Requirement,
+        skos:Concept ;
+    dct:description """The third unsigned short integer in the GeoKeyDirectoryTag SHALL hold the
+MinorRevision.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag> ;
+    skos:prefLabel "Requirement 2.8" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.minorRevisionValue> a spec:Requirement,
+        skos:Concept ;
+    dct:description """The MinorRevision for this standard SHALL be 0 or 1.0 = GeoTIFF 1.0 version.
+Accepted for existing files (GeoTIFF 1.0) that do not use values / codes that
+are suppressed in this version1 = this version 1.1. Recommended for production
+/ writing a GeoTIFF file according to this standard (and developing software).
+Shall be used for files keys and codes not covered by GeoTIFF 1.0 (e.g.
+VerticalGeoKey).""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag> ;
+    skos:prefLabel "Requirement 2.9" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.numberOfKeys> a spec:Requirement,
+        skos:Concept ;
+    dct:description """The fourth unsigned short integer in the GeoKeyDirectoryTag SHALL hold the
+NumberOfKeys defined in the rest of the GeoKeyDirectoryTag.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag> ;
+    skos:prefLabel "Requirement 2.10" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.type> a spec:Requirement,
+        skos:Concept ;
+    dct:description "The GeoKeyDirectoryTag SHALL have type = SHORT (2-byte unsigned integer)" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag> ;
+    skos:prefLabel "Requirement 2.2" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeySort> a spec:Requirement,
+        skos:Concept ;
+    dct:description """The GeoKey entries in a GeoTIFF file SHALL be written out to the file with the
+key-IDs sorted in ascending order""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/Core> ;
+    skos:prefLabel "Requirement 1.6" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.ID> a spec:Requirement,
+        skos:Concept ;
+    dct:description "The ModelPixelScaleTag SHALL have ID = 33550" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag> ;
+    skos:prefLabel "Requirement 10.1" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.axisReversal> a spec:Requirement,
+        skos:Concept ;
+    dct:description """Simple reversals of orientation from the standard relationship between raster
+and model space (e.g., horizontal or vertical flips) SHALL be indicated by
+reversal of sign in the corresponding component of the ModelPixelScaleTag.
+GeoTIFF compliant readers shall honor this sign-reversal convention.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag> ;
+    skos:prefLabel "Requirement 10.5" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.standardConvention> a spec:Requirement,
+        skos:Concept ;
+    dct:description """A positive ScaleX in the ModelPixelScaleTag SHALL indicate that model space X
+coordinates increase as raster space I indices increase. This is the standard
+horizontal relationship between raster space and model space. A positive
+ScaleY in the ModelPixelScaleTag SHALL indicate that model space Y coordinates
+decrease as raster space J indices increase. This is the standard vertical
+relationship between raster space and model space. The ScaleZ is primarily
+used to map the pixel value of a digital elevation model into the correct
+Z-scale (in other words a Z-Scaling factor).""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag> ;
+    skos:prefLabel "Requirement 10.4" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.type> a spec:Requirement,
+        skos:Concept ;
+    dct:description "The ModelPixelScaleTag SHALL have type = DOUBLE" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag> ;
+    skos:prefLabel "Requirement 10.2" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag.ID> a spec:Requirement,
+        skos:Concept ;
+    dct:description "The ModelTiepointTag SHALL have ID = 33922" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag> ;
+    skos:prefLabel "Requirement 9.1" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag.count> a spec:Requirement,
+        skos:Concept ;
+    dct:description "The ModelTiepointTag SHALL have 6 values for each of the tiepoints" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag> ;
+    skos:prefLabel "Requirement 9.3" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag.type> a spec:Requirement,
+        skos:Concept ;
+    dct:description "The ModelTiepointTag SHALL have type = DOUBLE" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag> ;
+    skos:prefLabel "Requirement 9.2" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag.ID> a spec:Requirement,
+        skos:Concept ;
+    dct:description "The ModelTransformationTag SHALL have ID = 34264" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag> ;
+    skos:prefLabel "Requirement 11.1" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag.count> a spec:Requirement,
+        skos:Concept ;
+    dct:description """The ModelTransformationTag SHALL have 16 values representing the terms of the
+4 by 4 transformation matrix. The terms SHALL be in row-major order""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag> ;
+    skos:prefLabel "Requirement 11.3" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag.type> a spec:Requirement,
+        skos:Concept ;
+    dct:description "The ModelTransformationTag SHALL have type = DOUBLE" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag> ;
+    skos:prefLabel "Requirement 11.2" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/TagSort> a spec:Requirement,
+        skos:Concept ;
+    dct:description """The TIFF tags in a GeoTIFF file SHALL be written out to the file with the tag-
+IDs sorted in ascending order""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/Core> ;
+    skos:prefLabel "Requirement 1.5" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/csuite> a spec:ConformanceSuite,
+        skos:Concept ;
+    spec:class <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Core>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey> .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ByteOrder> a spec:Requirement,
+        skos:Concept ;
+    dct:description """GeoTIFF implementation software SHALL honor the 'byte-order' indicator by
+performing byte swaps as necessary to provide an accurate in-memory
+representation of the values encoded in the GeoTIFF file""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/Core> ;
+    skos:prefLabel "Requirement 1.4" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.ID> a spec:Requirement,
+        skos:Concept ;
+    dct:description "The GeoAsciiParamsTag SHALL have ID = 34737" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag> ;
+    skos:prefLabel "Requirement 6.1" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoDoubleParamsTag> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoDoubleParamsTag.ID>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoDoubleParamsTag.count> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition "The following requirements govern the storage of parameter values when the values are of type Double." ;
+    skos:prefLabel "Requirements Class GeoDoubleParamsTag" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoDoubleParamsTag.ID> a spec:Requirement,
+        skos:Concept ;
+    dct:description "The GeoDoubleParamsTag SHALL have ID = 34736" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoDoubleParamsTag> ;
+    skos:prefLabel "Requirement 5.1" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoDoubleParamsTag.count> a spec:Requirement,
+        skos:Concept ;
+    dct:description """The GeoDoubleParamsTag MAY hold any number of key parameters with type =
+Double.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoDoubleParamsTag> ;
+    skos:prefLabel "Requirement 5.2" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyCode> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyCode.undefined>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyCode.userDefined> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition """For consistency, several key codes have the same meaning in all implemented GeoKeys
+
+The undefined code means that this parameter is intentionally omitted or unknown.
+
+In some cases, additional GeoKeys are required when the User-Defined value is used. Those requirements are included within a Requirements Class, where appropriate.""" ;
+    skos:prefLabel "Requirements Class GeoKeyCode" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoShortParamsTag> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoShortParamsTag.Criteria>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoShortParamsTag.Location> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition "The following requirements govern the storage of parameter values when there are two or more values of type Short." ;
+    skos:prefLabel "Requirements Class GeoShortParamsTag" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/TIFF> a spec:Requirement,
+        skos:Concept ;
+    dct:description "A GeoTIFF file SHALL be compliant with the TIFF 6.0 specification" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/Core> ;
+    skos:prefLabel "Requirement 1.1" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey> a spec:ConformanceClass,
+        skos:Concept ;
+    spec:conformanceTest <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey/ModelPixelScaleTag>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey/ModelTiepointTag>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Raster2Model_CoordinateTransformation_GeoKey/ModelTransformationTag> ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/csuite> ;
+    skos:prefLabel "Conformance Class Raster2Model_CoordinateTransformation_GeoKey" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/CitationGeoKeys> a spec:RequirementClass,
+        skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/CitationGeoKeys.ID>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/CitationGeoKeys.type> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
     skos:definition """The GTCitationGeoKey is provided to give an ASCII reference to published documentation on the overall configuration of the GeoTIFF file.
 The GeodeticCitationGeoKey, ProjectedCitationGeoKey and VerticalCitationGeoKey are used to describe Model CRS elements through ASCII free text. A citation may be included with a CRS identified through the GeoTIFF CRS register ([Requirements for definition of Model CRS (when Model CRS is from GeoTIFF CRS register)]). A citation is mandatory for a user-defined CRSs and CRS objects (Requirements for definition of user-defined Model CRS). The GeodeticCitationGeoKey, ProjectedCitationGeoKey and VerticalCitationGeoKey are used with CRSs and CRS components.
 
@@ -1618,32 +1911,175 @@ Note
 In GeoTIFF 1.0 the GeodeticCitationGeoKey key was called GeogCitationGeoKey and the ProjectedCitationGeoKey key was called PCSCitationGeoKey.""" ;
     skos:prefLabel "Requirements Class Citation GeoKeys" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/DataGeoTags> a spec:Requirement ;
-    dct:description """GeoTIFF files SHALL encode all GeoTIFF specific information using the
-following specified reserved TIFF tags \\\\- 34735 GeoKeyDirectoryTag (mandatory)
-\\\\- 34736 GeoDoubleParamsTag (optional) \\\\- 34737 GeoAsciiParamsTag (optional)
-\\\\- 33550 ModelPixelScaleTag (optional) \\\\- 33922 ModelTiepointTag (conditional)
-\\\\- 34264 ModelTransformationTag (conditional) The conditional tags shall
-follow the following rules: \\\\- One of ModelTiepointTag or
-ModelTransformationTag SHALL be included in an Image File Directory (IFD) \\\\-
-If the ModelTransformationTag is included in an IFD, then a ModelPixelScaleTag
-SHALL NOT be included \\\\- If the ModelPixelScaleTag is included in an IFD, then
-a ModelTiepointTag SHALL also be included.""" ;
-    skos:prefLabel "Requirement 1.2" .
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntryKeyCount> a spec:Requirement,
+        skos:Concept ;
+    dct:description """The Third unsigned short integer in the Key Entry SHALL indicate the number of
+values associated with this key.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag> ;
+    skos:prefLabel "Requirement 2.15" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/DataTypes> a spec:Requirement ;
-    dct:description """GeoTIFF implementation software SHALL support all documented TIFF 6.0 tag
-data-types, and in particular ASCII, SHORT and the IEEE double-precision
-floating point "DOUBLE" types""" ;
-    skos:prefLabel "Requirement 1.3" .
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntryValueOffset> a spec:Requirement,
+        skos:Concept ;
+    dct:description """The fourth unsigned short integer in the Key Entry SHALL hold either the key
+value (if TIFF Tag location = 0) or the index into the tag indicated by the
+TIFF Tag Location value.""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag> ;
+    skos:prefLabel "Requirement 2.16" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey> a spec:RequirementClass ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag.ID>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag.count>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag.type> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition "" ;
+    skos:prefLabel "Requirements Class ModelTiepointTag" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag.ID>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag.count>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag.type> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition "" ;
+    skos:prefLabel "Requirements Class ModelTransformationTag" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntryTIFFTagLocation> a spec:Requirement,
+        skos:Concept ;
+    dct:description """The second unsigned short integer in the Key Entry SHALL hold the TIFF Tag
+Location. The value of this entry shall be a valid GeoTIFF tag identifier or a
+zero (0)""" ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag> ;
+    skos:prefLabel "Requirement 2.14" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianLongitudeGeoKey> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianLongitudeGeoKey.ID>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianLongitudeGeoKey.type>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianLongitudeGeoKey.units> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition """This key allows definition of a user-defined Prime Meridian, the location of which is defined by its longitude relative to the international reference meridian (for the earth this is Greenwich).
+
+
+
+
+Note
+
+
+In GeoTIFF 1.0 this key was called GeogPrimeMeridianLongGeoKey.""" ;
+    skos:prefLabel "Requirements Class PrimeMeridianLongitudeGeoKey" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey.ID>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey.type>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey.units> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition """These keys allow the definition of size of user-defined angular and linear units, given in the SI base unit for that unit type (meters for length, radians for angle).
+
+Note: this specification does not support user-defined units for vertical coordinate reference systems.""" ;
+    skos:prefLabel "Requirements Class Unit Size GeoKeys" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.ID>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.NULLWrite>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.count>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.terminator>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.type> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition """The following requirements govern the storage of parameter values when the values are of type ASCII. All text values in a TIFF file must be null-terminated ASCII.
+
+Example of a GeoAscii tag containing only one string: NAD27 / UTM zone 11N|{NULL} (where {NULL} is the ASCII character of code 0)
+
+Example of a GeoAscii tag containing two strings: NAD27 / UTM zone 11N|NAD27|{NULL}""" ;
+    skos:prefLabel "Requirements Class GeoAsciiParamsTag" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.ID>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.axisReversal>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.count>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.standardConvention>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.type> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition "" ;
+    skos:prefLabel "Requirements Class ModelPixelScaleTag" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/Core> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ByteOrder>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/DataGeoTags>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/DataTypes>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeySort>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/TIFF>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/TagSort> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition "A GeoTIFF file is a valid TIFF 6.0 file." ;
+    skos:prefLabel "Requirements Class TIFF" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.ID>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.private>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.reserved>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.type>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.value> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition """This requirements class establishes the Raster Space used. There are currently only two options: RasterPixelIsPoint and RasterPixelIsArea. No user-defined raster spaces are currently supported. For variance in imaging display parameters, such as pixel aspect-ratios, use the standard TIFF 6.0 device-space tags.
+
+The use of this geokey is highly recommended for accurate georeferencing of raster.""" ;
+    skos:prefLabel "Requirements Class GTRasterTypeGeoKey" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/conf/Core> a spec:ConformanceClass,
+        skos:Concept ;
+    spec:conformanceTest <http://www.opengis.net/spec/GeoTIFF/1.1/conf/AsciiParameters>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/conf/DoubleParameters>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/conf/GeoKeyDirectory>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/conf/ShortParameters>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/conf/TIFF.Tags>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Core/test> ;
+
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/csuite> ;
+    skos:prefLabel "Conformance Class TIFF" .
+
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/conf/Core/test> a spec:ConformanceTest,
+        skos:Concept ;
+    spec:method "%3Cdiv%20class%3D%22paragraph%22%3E%0A%3Cp%3EThere%20is%20no%20authoritative%20conformance%20test%20for%20TIFF%206.0.%0A2%20basic%20tests%20may%20be%20done%20on%20TIFF%20header%20%284%20first%20bytes%29%2C%20called%20TIFF%20magic%3A%0A%E2%80%A2%20Bytes%200-1%20%28byte%20order%20within%20the%20file%29%20%3D%200X4949%20%28%22II%22%20%3D%20little%20endian%29%20or%200X4D4D%20%28%22MM%22%20%3D%20big%20endian%29.%0A%E2%80%A2%20Bytes%202-3%20%3D%20the%20short%20integer%20value%2042%20interpreted%20using%20the%20byte%20order%20specified%20in%20bytes%200-1.%3C/p%3E%0A%3C/div%3E%3Cdiv%20class%3D%22paragraph%22%3E%0A%3Cp%3EThe%20best%20that%20can%20be%20achieved%20is%20to%20use%20a%20TIFF%20reference%20implementation%20to%20successfully%20read%20a%20GeoTIFF%20file.%20The%20OGC%20recommends%20the%20use%20of%20tiffdump%20based%20on%20the%20open%20source%20LibTIFF%20library%20%28%3Ca%20href%3D%22https%3A//gitlab.com/libtiff/libtiff%22%20class%3D%22bare%22%3Ehttps%3A//gitlab.com/libtiff/libtiff%3C/a%3E%29%20for%20dumping%20the%20content%20of%20TIFF%20tags%20%28displaying%20error%20messages%20if%20any%29%2C%20or%20opensource%20TIFF%20file%20validator%20%28such%20as%20the%20JHOVE%20tool%2C%20opensource%20developed%20in%20Java%20-%20cf.%20%3Ca%20href%3D%22http%3A//jhove.openpreservation.org/%22%20class%3D%22bare%22%3Ehttp%3A//jhove.openpreservation.org/%3C/a%3E%29.%3C/p%3E%0A%3C/div%3E%3Cdiv%20class%3D%22paragraph%22%3E%0A%3Cp%3EOnce%20TIFF%206.0%20conformance%20has%20been%20validated%2C%20execute%20test%20%3Ca%20href%3D%22http%3A//www.opengis.net/spec/GeoTIFF/1.1/conf/TIFF.Tags%22%20class%3D%22bare%22%3Ehttp%3A//www.opengis.net/spec/GeoTIFF/1.1/conf/TIFF.Tags%3C/a%3E.%3C/p%3E%0A%3C/div%3E"^^rdf:HTML,
+        """There is no authoritative conformance test for TIFF 6.0. 2 basic tests may be
+done on TIFF header (4 first bytes), called TIFF magic: • Bytes 0-1 (byte
+order within the file) = 0X4949 (II = little endian) or 0X4D4D (MM = big
+endian). • Bytes 2-3 = the short integer value 42 interpreted using the byte
+order specified in bytes 0-1.
+
+The best that can be achieved is to use a TIFF reference implementation to
+successfully read a GeoTIFF file. The OGC recommends the use of tiffdump based
+on the open source LibTIFF library (<https://gitlab.com/libtiff/libtiff>) for
+dumping the content of TIFF tags (displaying error messages if any), or
+opensource TIFF file validator (such as the JHOVE tool, opensource developed
+in Java - cf. <http://jhove.openpreservation.org/>).
+
+Once TIFF 6.0 conformance has been validated, execute test
+<http://www.opengis.net/spec/GeoTIFF/1.1/conf/TIFF.Tags>.""" ;
+    spec:requirement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ByteOrder>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/DataTypes>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/TIFF> ;
+    spec:purpose "Verify that the GeoTIFF file conforms to the TIFF specification." ;
+    spec:testType spec:Basic ;
+    skos:broader <http://www.opengis.net/spec/GeoTIFF/1.1/conf/Core>;
+    skos:prefLabel "TIFF Core Test" .
+
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey> a spec:RequirementClass,
+        skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey.EPSG>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey.ID>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey.private>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey.reserved>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey.type>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey.user-defined> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
     skos:definition """This key is provided to specify an ellipsoid (or sphere) from the GeoTIFF CRS register or to indicate that the ellipsoid (or sphere) is user-defined.
 
 
@@ -1655,7 +2091,163 @@ Note
 In GeoTIFF 1.0 this key was called GeogEllipsoidGeoKey.""" ;
     skos:prefLabel "Requirements Class EllipsoidGeoKey" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey> a spec:RequirementClass ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.EPSG>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.ID>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.private>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.reserved>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.type>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.user-defined> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition """This key is provided to specify the geodetic (geographic or geocentric) coordinate reference system from the GeoTIFF CRS register or to indicate that the Model CRS is a user-defined geodetic coordinate reference system.
+
+
+
+
+Note
+
+
+In GeoTIFF 1.0 this key was called GeographicTypeGeoKey. Geodetic CRS is a superset of geographic 2D CRS, geographic 3D CRS and geocentric (earth-centred 3D Cartesian) CRS.""" ;
+    skos:prefLabel "Requirements Class GeodeticCRSGeoKey" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.EPSG>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.ID>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.private>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.reserved>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.type>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.userdefined> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition """This key is used to specify a geodetic datum from the GeoTIFF CRS register, or to indicate that the geodetic datum or one or both of its component ellipsoid or prime meridian is user-defined.
+
+
+
+
+Note
+
+
+In GeoTIFF 1.0 this key was called GeogGeodeticDatumGeoKey.""" ;
+    skos:prefLabel "Requirements Class GeodeticDatumGeoKey" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.EPSG>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.ID>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.private>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.reserved>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.type>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.userdefined> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition """This key is used to specify a Prime Meridian from the GeoTIFF CRS register or to indicate that the Prime Meridian is user-defined. The default is Greenwich, England.
+
+
+
+
+Note
+
+
+In GeoTIFF 1.0 this key was called GeogPrimeMeridianGeoKey.""" ;
+    skos:prefLabel "Requirements Class PrimeMeridianGeoKey" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.ID>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.private>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.reserved>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.transform>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.type>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.userdefined> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition """The ProjMethodGeoKey key is used to specify a map projection method from the GeoTIFF v1.0 coordinate transformation code list (Annex C) or to indicate that the map projection method is user-defined.
+
+
+
+
+Note
+
+
+In GeoTIFF 1.0 this key was called ProjCoordTransGeoKey.
+
+
+
+
+
+
+
+Note
+
+
+GeoTIFF v1.0 did not make reference to the EPSG coordinate operation methods (a future version of GeoTIFF might do this).""" ;
+    skos:prefLabel "Requirements Class ProjMethodGeoKey (coordinate operation method)" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.EPSG>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.ID>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.private>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.reserved>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.type>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.userdefined> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition """This key is used to specify the projected coordinate reference system from the GeoTIFF CRS register or to indicate that the Model CRS is a user-defined projected coordinate reference system.
+
+
+
+
+Note
+
+
+In GeoTIFF 1.0 this key was called ProjectedCSTypeGeoKey.""" ;
+    skos:prefLabel "Requirements Class ProjectedCRSGeoKey" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.EPSG>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.ID>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.private>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.reserved>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.type>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.userdefined> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition "The ProjectionGeoKey key is used to specify a map projection from the GeoTIFF CRS register or to indicate that the map projection is user-defined. In the EPSG Dataset a map projection is a coordinate conversion, a subtype of coordinate operation." ;
+    skos:prefLabel "Requirements Class ProjectionGeoKey" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.EPSG>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.ID>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.private>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.reserved>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.type>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.userdefined> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition "This key may be used to specify the vertical datum for a user-defined vertical coordinate reference system." ;
+    skos:prefLabel "Requirements Class Vertical Datum" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.EPSG>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.ID>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.reserved>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.type>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.userdefined>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/reqVerticalGeoKey.private> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition """This key is provided to specify the vertical coordinate reference system from the GeoTIFF CRS register or to indicate that the CRS is a user-defined vertical coordinate reference system. The value for VerticalGeoKey should follow the recommendations for including height in model CRS definitions as provided in Annex D.
+
+
+
+
+Note
+
+
+In GeoTIFF 1.0 this key was called VerticalCSTypeGeoKey. In GeoTIFF v1.0 vertical coordinate reference systems were described in draft form, with the statement Vertical coordinate systems are not yet implemented. These sections are provided for future development, and any vertical coordinate systems in the current revision must be defined using the VerticalCitationGeoKey.""" ;
+    skos:prefLabel "Requirements Class VerticalGeoKey" .
+
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey> a spec:RequirementClass,
+        skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidInvFlatteningGeoKey.ID>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidInvFlatteningGeoKey.type>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey.ID>,
@@ -1664,6 +2256,7 @@ In GeoTIFF 1.0 this key was called GeogEllipsoidGeoKey.""" ;
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMinorAxisGeoKey.ID>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMinorAxisGeoKey.type>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMinorAxisGeoKey.units> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
     skos:definition """These keys are used to specify the size and shape of a user-defined ellipsoid or sphere used as the model of the earth. Only bi-axial ellipsoids and spheres are catered for. An ellipsoid is defined through two parameters,
 
 its semi-major axis (a)
@@ -1674,7 +2267,7 @@ If the model is a sphere, 1/f is infinite so a and b must be used, with the valu
 
 Requirements Class EllipsoidSemiMajorAxisGeoKey
 
-This key is provided to specify the first defining parameter of a user-defined bi-axial ellipsoid  or a user-defined sphere. It allows the specification of the ellipsoid semi-major axis (a) or the sphere's radius.
+This key is provided to specify the first defining parameter of a user-defined bi-axial ellipsoid  or a user-defined sphere. It allows the specification of the ellipsoid semi-major axis (a) or the sphere’s radius.
 
 
 
@@ -1689,7 +2282,7 @@ In GeoTIFF 1.0 this key was called GeogSemiMajorAxisGeoKey.
 
 Requirements Class EllipsoidSemiMinorAxisGeoKey
 
-This key is provided to specify the second defining parameter of a user-defined bi-axial ellipsoid or of a user-defined sphere. It allows the specification of the ellipsoid semi-minor axis (b) or the sphere's radius.
+This key is provided to specify the second defining parameter of a user-defined bi-axial ellipsoid or of a user-defined sphere. It allows the specification of the ellipsoid semi-minor axis (b) or the sphere’s radius.
 
 
 
@@ -1715,7 +2308,8 @@ Note
 In GeoTIFF 1.0 this key was called GeogInvFlatteningGeoKey.""" ;
     skos:prefLabel "Requirements Class Ellipsoid parameter GeoKeys" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey> a spec:RequirementClass ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey> a spec:RequirementClass,
+        skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.ID>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.geocenCRS>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.geogCRS>,
@@ -1726,6 +2320,7 @@ In GeoTIFF 1.0 this key was called GeogInvFlatteningGeoKey.""" ;
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.type>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.userdefined>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey.value> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
     skos:definition """This GeoKey defines the type of Model coordinate reference system used, to which the transformation from the raster space is made:
 
 
@@ -1761,289 +2356,8 @@ Note
 The GTCitationGeoKey is also provided to give an ASCII reference to published documentation on the overall configuration of the GeoTIFF file (see Requirements Class Citation GeoKeys).""" ;
     skos:prefLabel "Requirements Class GTModelTypeGeoKey" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.ID>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.private>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.reserved>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.type>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey.value> ;
-    skos:definition """This requirements class establishes the Raster Space used. There are currently only two options: RasterPixelIsPoint and RasterPixelIsArea. No user-defined raster spaces are currently supported. For variance in imaging display parameters, such as pixel aspect-ratios, use the standard TIFF 6.0 device-space tags.
-
-The use of this geokey is highly recommended for accurate georeferencing of raster.""" ;
-    skos:prefLabel "Requirements Class GTRasterTypeGeoKey" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.count> a spec:Requirement ;
-    dct:description """The GeoAsciiParamsTag SHALL contain the values of the key parameters of type =
-ASCII referenced by the GeoKeyDirectoryTag. If there is no key parameters of
-type = ASCII, it SHALL not be present""" ;
-    skos:prefLabel "Requirement 6.2" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.type> a spec:Requirement ;
-    dct:description "The GeoAsciiParamsTag SHALL have type = ASCII" ;
-    skos:prefLabel "Requirement 6.5" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.ID> a spec:Requirement ;
-    dct:description "The GeoKeyDirectoryTag SHALL have ID = 34735" ;
-    skos:prefLabel "Requirement 2.1" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.count> a spec:Requirement ;
-    dct:description """The GeoKeyDirectoryTag SHALL include at least 4 keys (short integers) as
-header information""" ;
-    skos:prefLabel "Requirement 2.3" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyDirectoryVersion> a spec:Requirement ;
-    dct:description """The first unsigned short integer in the GeoKeyDirectoryTag SHALL hold the
-KeyDirectoryVersion.""" ;
-    skos:prefLabel "Requirement 2.4" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyDirectoryVersionValue> a spec:Requirement ;
-    dct:description "The value of KeyDirectoryVersion SHALL be 1." ;
-    skos:prefLabel "Requirement 2.5" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntry> a spec:Requirement ;
-    dct:description """Each Key Entry in the Key Entry Set SHALL include 4 unsigned short integer
-values""" ;
-    skos:prefLabel "Requirement 2.12" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntryKeyID> a spec:Requirement ;
-    dct:description """The first unsigned short integer in the Key Entry SHALL hold the key
-identifier.""" ;
-    skos:prefLabel "Requirement 2.13" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntrySetCount> a spec:Requirement ;
-    dct:description """The GeoKeyDirectoryTag SHALL hold NumberOfKeys KeyEntry Sets in addition to
-the header information""" ;
-    skos:prefLabel "Requirement 2.11" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyRevision> a spec:Requirement ;
-    dct:description """The second unsigned short integer in the GeoKeyDirectoryTag SHALL hold the
-KeyRevision.""" ;
-    skos:prefLabel "Requirement 2.6" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyRevisionValue> a spec:Requirement ;
-    dct:description "The value of KeyRevision SHALL be 1." ;
-    skos:prefLabel "Requirement 2.7" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.minorRevision> a spec:Requirement ;
-    dct:description """The third unsigned short integer in the GeoKeyDirectoryTag SHALL hold the
-MinorRevision.""" ;
-    skos:prefLabel "Requirement 2.8" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.minorRevisionValue> a spec:Requirement ;
-    dct:description """The MinorRevision for this standard SHALL be 0 or 1.0 = GeoTIFF 1.0 version.
-Accepted for existing files (GeoTIFF 1.0) that do not use values / codes that
-are suppressed in this version1 = this version 1.1. Recommended for production
-/ writing a GeoTIFF file according to this standard (and developing software).
-Shall be used for files keys and codes not covered by GeoTIFF 1.0 (e.g.
-VerticalGeoKey).""" ;
-    skos:prefLabel "Requirement 2.9" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.numberOfKeys> a spec:Requirement ;
-    dct:description """The fourth unsigned short integer in the GeoKeyDirectoryTag SHALL hold the
-NumberOfKeys defined in the rest of the GeoKeyDirectoryTag.""" ;
-    skos:prefLabel "Requirement 2.10" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.type> a spec:Requirement ;
-    dct:description "The GeoKeyDirectoryTag SHALL have type = SHORT (2-byte unsigned integer)" ;
-    skos:prefLabel "Requirement 2.2" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeySort> a spec:Requirement ;
-    dct:description """The GeoKey entries in a GeoTIFF file SHALL be written out to the file with the
-key-IDs sorted in ascending order""" ;
-    skos:prefLabel "Requirement 1.6" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.EPSG>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.ID>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.private>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.reserved>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.type>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey.user-defined> ;
-    skos:definition """This key is provided to specify the geodetic (geographic or geocentric) coordinate reference system from the GeoTIFF CRS register or to indicate that the Model CRS is a user-defined geodetic coordinate reference system.
-
-
-
-
-Note
-
-
-In GeoTIFF 1.0 this key was called GeographicTypeGeoKey. Geodetic CRS is a superset of geographic 2D CRS, geographic 3D CRS and geocentric (earth-centred 3D Cartesian) CRS.""" ;
-    skos:prefLabel "Requirements Class GeodeticCRSGeoKey" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.EPSG>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.ID>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.private>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.reserved>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.type>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey.userdefined> ;
-    skos:definition """This key is used to specify a geodetic datum from the GeoTIFF CRS register, or to indicate that the geodetic datum or one or both of its component ellipsoid or prime meridian is user-defined.
-
-
-
-
-Note
-
-
-In GeoTIFF 1.0 this key was called GeogGeodeticDatumGeoKey.""" ;
-    skos:prefLabel "Requirements Class GeodeticDatumGeoKey" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.ID> a spec:Requirement ;
-    dct:description "The ModelPixelScaleTag SHALL have ID = 33550" ;
-    skos:prefLabel "Requirement 10.1" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.axisReversal> a spec:Requirement ;
-    dct:description """Simple reversals of orientation from the standard relationship between raster
-and model space (e.g., horizontal or vertical flips) SHALL be indicated by
-reversal of sign in the corresponding component of the ModelPixelScaleTag.
-GeoTIFF compliant readers shall honor this sign-reversal convention.""" ;
-    skos:prefLabel "Requirement 10.5" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.standardConvention> a spec:Requirement ;
-    dct:description """A positive ScaleX in the ModelPixelScaleTag SHALL indicate that model space X
-coordinates increase as raster space I indices increase. This is the standard
-horizontal relationship between raster space and model space. A positive
-ScaleY in the ModelPixelScaleTag SHALL indicate that model space Y coordinates
-decrease as raster space J indices increase. This is the standard vertical
-relationship between raster space and model space. The ScaleZ is primarily
-used to map the pixel value of a digital elevation model into the correct
-Z-scale (in other words a Z-Scaling factor).""" ;
-    skos:prefLabel "Requirement 10.4" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag.type> a spec:Requirement ;
-    dct:description "The ModelPixelScaleTag SHALL have type = DOUBLE" ;
-    skos:prefLabel "Requirement 10.2" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag.ID> a spec:Requirement ;
-    dct:description "The ModelTiepointTag SHALL have ID = 33922" ;
-    skos:prefLabel "Requirement 9.1" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag.count> a spec:Requirement ;
-    dct:description "The ModelTiepointTag SHALL have 6 values for each of the tiepoints" ;
-    skos:prefLabel "Requirement 9.3" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag.type> a spec:Requirement ;
-    dct:description "The ModelTiepointTag SHALL have type = DOUBLE" ;
-    skos:prefLabel "Requirement 9.2" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag.ID> a spec:Requirement ;
-    dct:description "The ModelTransformationTag SHALL have ID = 34264" ;
-    skos:prefLabel "Requirement 11.1" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag.count> a spec:Requirement ;
-    dct:description """The ModelTransformationTag SHALL have 16 values representing the terms of the
-4 by 4 transformation matrix. The terms SHALL be in row-major order""" ;
-    skos:prefLabel "Requirement 11.3" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag.type> a spec:Requirement ;
-    dct:description "The ModelTransformationTag SHALL have type = DOUBLE" ;
-    skos:prefLabel "Requirement 11.2" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.EPSG>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.ID>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.private>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.reserved>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.type>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey.userdefined> ;
-    skos:definition """This key is used to specify a Prime Meridian from the GeoTIFF CRS register or to indicate that the Prime Meridian is user-defined. The default is Greenwich, England.
-
-
-
-
-Note
-
-
-In GeoTIFF 1.0 this key was called GeogPrimeMeridianGeoKey.""" ;
-    skos:prefLabel "Requirements Class PrimeMeridianGeoKey" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianLongitudeGeoKey> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianLongitudeGeoKey.ID>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianLongitudeGeoKey.type>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianLongitudeGeoKey.units> ;
-    skos:definition """This key allows definition of a user-defined Prime Meridian, the location of which is defined by its longitude relative to the international reference meridian (for the earth this is Greenwich).
-
-
-
-
-Note
-
-
-In GeoTIFF 1.0 this key was called GeogPrimeMeridianLongGeoKey.""" ;
-    skos:prefLabel "Requirements Class PrimeMeridianLongitudeGeoKey" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.ID>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.private>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.reserved>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.transform>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.type>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey.userdefined> ;
-    skos:definition """The ProjMethodGeoKey key is used to specify a map projection method from the GeoTIFF v1.0 coordinate transformation code list (Annex C) or to indicate that the map projection method is user-defined.
-
-
-
-
-Note
-
-
-In GeoTIFF 1.0 this key was called ProjCoordTransGeoKey.
-
-
-
-
-
-
-
-Note
-
-
-GeoTIFF v1.0 did not make reference to the EPSG coordinate operation methods (a future version of GeoTIFF might do this).""" ;
-    skos:prefLabel "Requirements Class ProjMethodGeoKey (coordinate operation method)" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.EPSG>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.ID>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.private>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.reserved>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.type>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey.userdefined> ;
-    skos:definition """This key is used to specify the projected coordinate reference system from the GeoTIFF CRS register or to indicate that the Model CRS is a user-defined projected coordinate reference system.
-
-
-
-
-Note
-
-
-In GeoTIFF 1.0 this key was called ProjectedCSTypeGeoKey.""" ;
-    skos:prefLabel "Requirements Class ProjectedCRSGeoKey" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.EPSG>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.ID>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.private>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.reserved>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.type>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey.userdefined> ;
-    skos:definition "The ProjectionGeoKey key is used to specify a map projection from the GeoTIFF CRS register or to indicate that the map projection is user-defined. In the EPSG Dataset a map projection is a coordinate conversion, a subtype of coordinate operation." ;
-    skos:prefLabel "Requirements Class ProjectionGeoKey" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/TagSort> a spec:Requirement ;
-    dct:description """The TIFF tags in a GeoTIFF file SHALL be written out to the file with the tag-
-IDs sorted in ascending order""" ;
-    skos:prefLabel "Requirement 1.5" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey.ID>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey.type>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey.units> ;
-    skos:definition """These keys allow the definition of size of user-defined angular and linear units, given in the SI base unit for that unit type (meters for length, radians for angle).
-
-Note: this specification does not support user-defined units for vertical coordinate reference systems.""" ;
-    skos:prefLabel "Requirements Class Unit Size GeoKeys" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey> a spec:RequirementClass ;
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey> a spec:RequirementClass,
+        skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.ID>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.angular>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.linear>,
@@ -2054,6 +2368,7 @@ Note: this specification does not support user-defined units for vertical coordi
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.userdefinedGeogLinear>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.userdefinedProjLinear>,
         <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey.userdefinedVertical> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
     skos:definition """These keys are used to specify Units of Measure (UoM) through the identification of a unit from the GeoTIFF CRS register or to indicate that the unit is user-defined.
 
 The GeogAngularUnitsGeoKey key is used to specify the angular unit for:
@@ -2107,71 +2422,83 @@ The VerticalUnitsGeoKey key is used to specify the linear unit for:
 the axis of a user-defined vertical CRS.""" ;
     skos:prefLabel "Requirements Class Units GeoKeys" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.EPSG>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.ID>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.private>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.reserved>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.type>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey.userdefined> ;
-    skos:definition "This key may be used to specify the vertical datum for a user-defined vertical coordinate reference system." ;
-    skos:prefLabel "Requirements Class Vertical Datum" .
+<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag> a spec:RequirementClass,
+        skos:Concept ;
+    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.ID>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.count>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyDirectoryVersion>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyDirectoryVersionValue>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntry>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntryKeyCount>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntryKeyID>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntrySetCount>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntryTIFFTagLocation>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntryValueOffset>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyRevision>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyRevisionValue>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.minorRevision>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.minorRevisionValue>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.numberOfKeys>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.type> ;
+    skos:broader <http://www.opengis.net/def/docs/19-008r4> ;
+    skos:definition """The GeoKeyDirectoryTag Requirements Class specifies the requirements for implementing the reserved GeoKeyDirectoryTag TIFF tag.
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey> a spec:RequirementClass ;
-    spec:normativeStatement <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.EPSG>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.ID>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.reserved>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.type>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey.userdefined>,
-        <http://www.opengis.net/spec/GeoTIFF/1.1/reqVerticalGeoKey.private> ;
-    skos:definition """This key is provided to specify the vertical coordinate reference system from the GeoTIFF CRS register or to indicate that the CRS is a user-defined vertical coordinate reference system. The value for VerticalGeoKey should follow the recommendations for including height in model CRS definitions as provided in Annex D.
+A GeoTIFF file stores projection parameters in a set of Keys which are virtually identical in function to a TIFF tag, but have one more level of abstraction above TIFF. Like a tag, a Key has an ID number ranging from 0 to 65535, but unlike TIFF tags, all key ID’s are available for use in GeoTIFF parameter definitions.
+
+The Keys in GeoTIFF (also called GeoKeys) are all referenced from the GeoKeyDirectoryTag tag. The first four keys form the GeoKey Directory Header. The keys which make up this header are: KeyDirectoryVersion, KeyRevision, MinorRevision, and NumberOfKeys.
+
+The GeoKey Directory Header is followed by <NumberOfKeys> Key Entries. Each Key Entry consists of four values.
 
 
 
+KeyID gives the key-ID value of the Key (identical in function to TIFF tag ID, but completely independent of TIFF tag-space).
 
-Note
+
+TIFFTagLocation indicates which TIFF tag contains the value(s) of the Key: if TIFFTagLocation is 0, then the value is SHORT, and is contained in the ValueOffset entry. Otherwise, the type (format) of the value is implied by the TIFF-Type of the tag containing the value.
 
 
-In GeoTIFF 1.0 this key was called VerticalCSTypeGeoKey. In GeoTIFF v1.0 vertical coordinate reference systems were described in draft form, with the statement "Vertical coordinate systems are not yet implemented. These sections are provided for future development, and any vertical coordinate systems in the current revision must be defined using the VerticalCitationGeoKey.\"""" ;
-    skos:prefLabel "Requirements Class VerticalGeoKey" .
+Count indicates the number of values in this key.
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/ByteOrder> a spec:Requirement ;
-    dct:description """GeoTIFF implementation software SHALL honor the 'byte-order' indicator by
-performing byte swaps as necessary to provide an accurate in-memory
-representation of the values encoded in the GeoTIFF file""" ;
-    skos:prefLabel "Requirement 1.4" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag.ID> a spec:Requirement ;
-    dct:description "The GeoAsciiParamsTag SHALL have ID = 34737" ;
-    skos:prefLabel "Requirement 6.1" .
+ValueOffset ValueOffset indicates the index- offset into the TagArray indicated by TIFFTagLocation, if it is nonzero. If TIFFTagLocation=0, then ValueOffset contains the actual (SHORT) value of the Key, and Count=1 is implied. Note that the offset is not a byte-offset, but rather an index based on the natural data type of the specified tag array.""" ;
+    skos:prefLabel "Requirements Class GeoKeyDirectoryTag" .
 
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoDoubleParamsTag.ID> a spec:Requirement ;
-    dct:description "The GeoDoubleParamsTag SHALL have ID = 34736" ;
-    skos:prefLabel "Requirement 5.1" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoDoubleParamsTag.count> a spec:Requirement ;
-    dct:description """The GeoDoubleParamsTag MAY hold any number of key parameters with type =
-Double.""" ;
-    skos:prefLabel "Requirement 5.2" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/TIFF> a spec:Requirement ;
-    dct:description "A GeoTIFF file SHALL be compliant with the TIFF 6.0 specification" ;
-    skos:prefLabel "Requirement 1.1" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntryKeyCount> a spec:Requirement ;
-    dct:description """The Third unsigned short integer in the Key Entry SHALL indicate the number of
-values associated with this key.""" ;
-    skos:prefLabel "Requirement 2.15" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntryValueOffset> a spec:Requirement ;
-    dct:description """The fourth unsigned short integer in the Key Entry SHALL hold either the key
-value (if TIFF Tag location = 0) or the index into the tag indicated by the
-TIFF Tag Location value.""" ;
-    skos:prefLabel "Requirement 2.16" .
-
-<http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag.keyEntryTIFFTagLocation> a spec:Requirement ;
-    dct:description """The second unsigned short integer in the Key Entry SHALL hold the TIFF Tag
-Location. The value of this entry shall be a valid GeoTIFF tag identifier or a
-zero (0)""" ;
-    skos:prefLabel "Requirement 2.14" .
+<http://www.opengis.net/def/docs/19-008r4> a spec:Specification ;
+    dct:dateSubmitted "2019-06-05"^^xsd:date ;
+    dct:identifier "http://www.opengis.net/doc/IS/GeoTIFF/1.1" ;
+    reg:status reg:statusValid ;
+    na:doctype ogcdt:is ;
+    spec:authority "Open Geospatial Consortium" ;
+    spec:class <http://www.opengis.net/spec/GeoTIFF/1.1/req/CitationGeoKeys>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/Core>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidGeoKey>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/EllipsoidSemiMajorAxisGeoKey>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTModelTypeGeoKey>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GTRasterTypeGeoKey>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoAsciiParamsTag>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoDoubleParamsTag>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyCode>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoKeyDirectoryTag>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeoShortParamsTag>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticCRSGeoKey>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/GeodeticDatumGeoKey>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelPixelScaleTag>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTiepointTag>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ModelTransformationTag>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianGeoKey>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/PrimeMeridianLongitudeGeoKey>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjMethodGeoKey>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectedCRSGeoKey>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/ProjectionGeoKey>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitSizeGeoKey>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/UnitsGeoKey>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalDatumGeoKey>,
+        <http://www.opengis.net/spec/GeoTIFF/1.1/req/VerticalGeoKey> ;
+    spec:testSuite <http://www.opengis.net/spec/GeoTIFF/1.1/csuite> ;
+    skos:notation "19-008r4"^^na:doc_no ;
+    skos:note "Approved" ;
+    skos:prefLabel "OGC GeoTIFF standard" ;
+    adms:version "1.1" ;
+    dcat:landingPage <http://docs.opengeospatial.org/is/19-008r4/19-008r4.html> ;
+    dcmi:creator "Emmanuel Devys, Ted Habermann, Chuck Heazel, Roger Lott, Even Rouault" .
 


### PR DESCRIPTION
 - file regenerated with 19-008r4 in utf-8 without BOM. rdflib controls the order, bit sure why Specification is in the end currently,
 - added skos:Concept to ConformanceClass, Test, Requirement, Suite.
skos: broader relationship from Requirement to RequirementClass, test to ConformanceClass, ConformanceClass to ConformanceSuite,
 - conflict URI (http://www.opengis.net/spec/GeoTIFF/1.1/conf/Core) assigned originally to the Conformance Class and Test solved by the change in the test URI to http://www.opengis.net/spec/GeoTIFF/1.1/conf/Core/test