### PR TITLE
Update clause_7_name_assignment_policy.adoc

### DIFF
--- a/policyAndProcedures/OGCNANameTypeSpecificationForDefinitions/clause_7_name_assignment_policy.adoc
+++ b/policyAndProcedures/OGCNANameTypeSpecificationForDefinitions/clause_7_name_assignment_policy.adoc
@@ -1,4 +1,4 @@
-== Name Assignment Policy
+== Name Assignment and Resolution
 
 This section describes the name assignment policy.
 
@@ -18,11 +18,11 @@ The register of names http://www.opengis.net/def/ is controlled by OGC-NA. Chang
 
 http URI form:
 
-http://www.opengis.net/def/objectType/EPSG/0/code
+http://www.opengis.net/def/definitionType/EPSG/0/code
 
 URN form:
 
-urn:ogc:def:objectType:EPSG::code
+urn:ogc:def:definitionType:EPSG::code
 
 In this case, the 'authority' part of the URI is 'EPSG'. The 'code' part of the URI is the EPSG 'code' unique identifier of the referenced definition. Alternately, the 'code' part of the URI can be the EPSG 'name' unique identifier.  In this case, omission of the version number is recommended, as this is not required to identify a referenced record in the EPSG dataset and may even lead to confusion if a version number is provided.
 
@@ -83,3 +83,11 @@ An example of a definition described in SKOS is shown below.
   skos:definition "A Web Coverage Service (WCS) offers multi-dimensional coverage data for access over the Internet" .
 
 ----
+
+=== Resolution of the Same Definition to Different Encodings
+
+The definition of a resource may be accessed in any number of encodings that are supported by a resolution service or resolver. A resolution service and a client application shall negotiate the encoding format to use through the content negotiation process defined in http://docs.ogc.org/DRAFTS/19-072.html#rfc7231[IETF RFC 7231]. A non-exhaustive list of example encodings relevant to different resources is below:
+
+* Geography Markup Language (GML): Supports the encoding on features, coordinate reference systems, and codelists.
+* Well Known Text (WKT): Supports the encoding on features, and coordinate reference systems.
+* Simple Knowledge Organization System (SKOS) in Resource Description Framework (RDF): Supports the encoding concepts, glossaries, and thesauri


### PR DESCRIPTION
Two edits made:

* changes objectType to definitionType, so as to be consistent with the Naming Rule section
* add a section describing support for Content Negotiation