### PR TITLE
spec:dependency of classes plus entailment producing skos:narrower/br…

### DIFF
--- a/scripts/spec_as_conceptscheme.shapes.ttl
+++ b/scripts/spec_as_conceptscheme.shapes.ttl
@@ -103,11 +103,35 @@ CONSTRUCT {
   ?req skos:broader ?this .
 }
 WHERE {
-    
+
     FILTER NOT EXISTS { ?c skos:broader ?this }
 }""" ;
 .
 
 
+:NodeShape_class_dependency
+  a sh:NodeShape ;
+  sh:rule :classdependencies ;
+  rdfs:domain [
+      a owl:Class ;
+      owl:unionOf (
+          spec:RequirementsClass
+          spec:ConformanceClass
+        ) ;
+    ] ;
+.
 
-
+:classdependencies
+  a sh:SPARQLRule ;
+  rdfs:label "Create skos:broader hierarchy for spec:dependency" ;
+  sh:construct """PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+  		     prefix spec: <http://www.opengis.net/def/ont/modspec/>
+           CONSTRUCT {
+           ?c skos:broader ?this .
+           ?this skos:narrower ?c .
+           }
+           WHERE {
+               ?c spec:dependency ?this
+               FILTER NOT EXISTS { ?c skos:broader ?this } #not sure if this is most effective to query it instead of just adding second time same relation
+           }""" ;
+.

--- a/specification-elements/defs/15-111r1.ttl
+++ b/specification-elements/defs/15-111r1.ttl
@@ -22,25 +22,27 @@
 
 
 
+
 <http://www.opengis.net/spec/landinfra/1.0> a skos:ConceptScheme ;
   dct:source <http://www.opengis.net/def/docs/15-111r1> ;
   skos:prefLabel "Specification elements for OGC 15-111r LandInfra" ;
   skos:definition "A convenience hierarchy for navigating the elements of a specification using the SKOS model" ;
   dct:modified "2016-12-20"^^xsd:date ;
    dct:created "2016-12-20"^^xsd:date ;
-   skos:hasTopConcept <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ,
-     <http://www.opengis.net/spec/landinfra/1.0/conf/condominium> ,
-     <http://www.opengis.net/spec/landinfra/1.0/conf/equipment> ,
-     <http://www.opengis.net/spec/landinfra/1.0/conf/land-division> ,
-     <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature> ,
-     <http://www.opengis.net/spec/landinfra/1.0/conf/observations> ,
-     <http://www.opengis.net/spec/landinfra/1.0/conf/railway> ,
-     <http://www.opengis.net/spec/landinfra/1.0/conf/road> ,
-     <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section> ,
-     <http://www.opengis.net/spec/landinfra/1.0/conf/survey> ,
-     <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results> ,
-     <http://www.opengis.net/spec/landinfra/1.0/conf/project> ,
-     <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ,
+   skos:hasTopConcept
+#     <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ,
+#     <http://www.opengis.net/spec/landinfra/1.0/conf/condominium> ,
+#     <http://www.opengis.net/spec/landinfra/1.0/conf/equipment> ,
+#     <http://www.opengis.net/spec/landinfra/1.0/conf/land-division> ,
+#     <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature> ,
+#     <http://www.opengis.net/spec/landinfra/1.0/conf/observations> ,
+#     <http://www.opengis.net/spec/landinfra/1.0/conf/railway> ,
+#     <http://www.opengis.net/spec/landinfra/1.0/conf/road> ,
+#     <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section> ,
+#     <http://www.opengis.net/spec/landinfra/1.0/conf/survey> ,
+#     <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results> ,
+#     <http://www.opengis.net/spec/landinfra/1.0/conf/project> ,
+#     <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ,
      <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra>
 .
 
@@ -52,9 +54,11 @@
         <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/CRS> ,
         <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/LR-interfaces> ,
         <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/measures> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
-    skos:definition "Conformance Class: Alignment" ;
+    #skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
     skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/alignment> ;
+
+    skos:definition "An alignment is a positioning element which provides a Linear Referencing System for locating physical elements.  The Alignment Requirements Class specifies how an alignment is defined and used." ;
     skos:prefLabel "Conformance Class: Alignment" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/classes> a spec:ConformanceTest,
@@ -65,7 +69,6 @@
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/alignment/classes> ;
     spec:testType spec:Capabilities ;
     skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/description> a spec:ConformanceTest,
@@ -87,7 +90,6 @@
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/alignment/CRS> ;
     spec:testType spec:Capabilities ;
     skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/CRS" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/LR-interfaces> a spec:ConformanceTest,
@@ -98,7 +100,6 @@
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/alignment/LR-interfaces> ;
     spec:testType spec:Capabilities ;
     skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/LR-interfaces" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/measures> a spec:ConformanceTest,
@@ -113,16 +114,15 @@
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/alignment/measures> ;
     spec:testType spec:Capabilities ;
     skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/measures" .
 
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/condominium> a spec:ConformanceClass,
         skos:Concept ;
     spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/condominium/classes> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
-    skos:definition "Conformance Class: Condominium" ;
-
+    #skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-division> ;
+    skos:definition "A condominium denotes concurrent ownership of real property that has been divided into private and common portions.  The Condominium Requirements Class includes information about condominium units, buildings and schemes." ;
     skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/condominium> ;
     skos:prefLabel "Conformance Class: Condominium" .
 
@@ -134,16 +134,15 @@
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/condominium/classes> ;
     spec:testType spec:Capabilities ;
     skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/condominium> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/condominium/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/equipment> a spec:ConformanceClass,
         skos:Concept ;
     spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/equipment/classes> ,
         <http://www.opengis.net/spec/landinfra/1.0/conf/equipment/observation-correction> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
-    skos:definition "Conformance Class: Equipment" ;
-
+    #skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    skos:definition "In the Equipment Requirements class all information about the processes and the sensors is available that had been used for the determination of an observation." ;
+    skos:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/survey> ;
     skos:prefLabel "Conformance Class: Equipment" ;
     skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/equipment> .
 
@@ -171,7 +170,6 @@
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/facility/classes> a spec:ConformanceTest,
         skos:Concept ;
-    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
     skos:definition """Verify that the encoding provides the Facility Requirements class Classes shown in blue in Figure 10 in a manner consistent with the encoding.""" ;
     spec:method "Inspect the encoding to verify the above requirement." ;
     spec:purpose """Verify that the encoding provides the Facility Requirements class Classes shown in blue in Figure 10 in a manner consistent with the encoding.""" ;
@@ -183,23 +181,23 @@
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes> a spec:ConformanceTest,
         skos:Concept ;
-    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
+    #spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
     spec:method "Inspect the encoding to verify the above requirement." ;
     spec:purpose """Verify that the encoding specifies which of the FacilityPart subtypes shown in Figure 10 it supports.""" ;
     skos:definition """Verify that the encoding specifies which of the FacilityPart subtypes shown in Figure 10 it supports.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/facility/subtypes> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes> ;
+    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
 
     skos:prefLabel "ConformanceTest: http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/land-division> a spec:ConformanceClass,
         skos:Concept ;
     spec:conformanceTest  <http://www.opengis.net/spec/landinfra/1.0/conf/land-division/classes> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
-
+    # skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
     skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/land-division> ;
-    skos:definition "Conformance Class: LandDivision" ;
+    skos:definition "Land can be divided up into land divisions.  These can either be public (political, judicial, or executive) or private in nature.  The former are administrative divisions and the latter are interests in land.  Both of these are specified in the LandDivision Requirements Class, though condominium interests in land are specified in a separate, Condominium Requirements Class." ;
     skos:prefLabel "Conformance Class: LandDivision" .
 
 
@@ -218,10 +216,10 @@
         skos:Concept ;
     spec:conformanceTest  <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/classes> ,
         <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
-
+    # skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
     skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/land-feature> ;
-    skos:definition "Conformance Class: LandFeature" ;
+    skos:definition "Features of the land, such as naturally occurring water features and vegetation are specified in the LandFeature Requirements Class as land features.  Also included are models of the land surface and subsurface layers.  Improvements to the land such as the construction of an embankment or the planting of landscape material are considered to be part of Site Facilities in the Facility Requirements Class." ;
     skos:prefLabel "Conformance Class: LandFeature" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/classes> a spec:ConformanceTest,
@@ -242,7 +240,7 @@
     skos:definition """If an encoding allows the linear element used for a LandLayer to be an Alignment, then verify that the encoding supports the Alignment Requirements class.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/land-feature/alignment> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment> ;
+    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature> ;
 
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment" .
 
@@ -361,10 +359,10 @@
 <http://www.opengis.net/spec/landinfra/1.0/conf/observations> a spec:ConformanceClass,
         skos:Concept ;
     spec:conformanceTest  <http://www.opengis.net/spec/landinfra/1.0/conf/observations/classes> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
-
+    #skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/survey> ;
     skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/observations> ;
-    skos:definition "Conformance Class: Observations" ;
+    skos:definition "Observations Requirements class is the package containing all information about the raw observations and the measurements observed during survey work. The raw observations are needed to enable later reprocessing or reporting of resulting properties of the observed feature of interest." ;
     skos:prefLabel "Conformance Class: Observations" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/observations/classes> a spec:ConformanceTest,
@@ -380,7 +378,7 @@
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/project/classes> a spec:ConformanceTest,
         skos:Concept ;
-    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
+    #spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
     spec:method "Inspect the encoding to verify the above requirement." ;
     spec:purpose """Verify that the encoding provides the Project Requirements Class Classes shown in blue in Figure 13 in a manner consistent with the encoding.""" ;
     skos:definition """Verify that the encoding provides the Project Requirements Class Classes shown in blue in Figure 13 in a manner consistent with the encoding.""" ;
@@ -395,10 +393,11 @@
     spec:conformanceTest  <http://www.opengis.net/spec/landinfra/1.0/conf/railway/classes> ,
         <http://www.opengis.net/spec/landinfra/1.0/conf/railway/alignment> ,
         <http://www.opengis.net/spec/landinfra/1.0/conf/railway/cant> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    #skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
     skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/railway> ;
 
-    skos:definition "Conformance Class: Railway" ;
+    skos:definition "The Railway Requirements Class supports those use cases where a designer wishes to exchange the output of the railway design with someone who is likely to use if for purposes other than further design. Consequently, the Railway Requirements Class covers design output such as 3D railway elements and track geometry including superelevation (cant)." ;
     skos:prefLabel "Conformance Class: Railway" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/railway/classes> a spec:ConformanceTest,
@@ -438,10 +437,11 @@
         skos:Concept ;
     spec:conformanceTest  <http://www.opengis.net/spec/landinfra/1.0/conf/road/classes> ,
         <http://www.opengis.net/spec/landinfra/1.0/conf/road/alignment> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    # skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
     skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/road> ;
 
-    skos:definition "Conformance Class: Road" ;
+    skos:definition "The Road Requirements Class supports those use cases in which a designer wishes to exchange the output of the design with someone who is likely to use it for purposes other than completing the road design.  Consequently, the Road Requirements Class includes several alternative ways for representing a design such as with 3D RoadElements, 3D StringLines (aka profile views, longitudinal breaklines, long sections), and 3D surfaces and layers, as well as collections of these." ;
     skos:prefLabel "Conformance Class: Road" .
 
 
@@ -471,10 +471,11 @@
         skos:Concept ;
     spec:conformanceTest  <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/classes> ,
         <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/alignment> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    # skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/road> ;
     skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section> ;
 
-    skos:definition "Conformance Class: RoadCrossSection" ;
+    skos:definition "The RoadCrossSection Requirements Class extends the Road Requirements Class by adding the 2D CrossSection alternative way of representing a design, as well as collections of these." ;
     skos:prefLabel "Conformance Class: RoadCrossSection" .
 
 
@@ -503,10 +504,11 @@
 <http://www.opengis.net/spec/landinfra/1.0/conf/survey> a spec:ConformanceClass,
         skos:Concept ;
     spec:conformanceTest  <http://www.opengis.net/spec/landinfra/1.0/conf/survey/classes> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    #skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
     skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/survey> ;
 
-    skos:definition "Conformance Class: Survey" ;
+    skos:definition "The Survey Requirements Class is the main survey class and provides a framework for information about observations, processes and their results collected during survey work. The content of this package is similar to the OGC Sensor Model Language (SensorML). The main reason not to use the SensorML standard for this topic is to allow the observation and processes structured in a compact way similar to the LandXML format. Due to the high number of classes the Survey Package was split into different parts, Equipment, Observations and SurveyResults." ;
     skos:prefLabel "Conformance Class: Survey" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/survey/classes> a spec:ConformanceTest,
@@ -524,11 +526,12 @@
         skos:Concept ;
     spec:conformanceTest  <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/classes> ,
         <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/topic-20> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    #skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/survey> ;
     skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/survey-results> ;
 
-    skos:definition "Conformance Class: SurveyResults" ;
-    skos:prefLabel "Conformance Class: SurveyResults" .
+    skos:definition "The SurveyResults Requirements Class contains the observed property of a feature of interest.  Using sampling features from the Observation & Measurements (O&M) standard, the dependencies between the observation acts and the results are realized." ;
+    skos:prefLabel "Conformance Class: Survey Results" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/classes> a spec:ConformanceTest,
         skos:Concept ;
@@ -598,8 +601,8 @@ manner as is consistent with the encoding.""" ;
         skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/condominium/classes> ;
     skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/condominium> ;
-
-    skos:definition "Requirement Class: Condominium" ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/land-division> ;
+    skos:definition "A condominium denotes concurrent ownership of real property that has been divided into private and common portions.  The Condominium Requirements Class includes information about condominium units, buildings and schemes." ;
     skos:prefLabel "Requirement Class: Condominium" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/condominium/classes> a spec:Requirement,
@@ -645,9 +648,9 @@ manner as is consistent with the encoding.""" ;
 <http://www.opengis.net/spec/landinfra/1.0/req/land-division> a spec:RequirementClass,
         skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/land-division/classes> ;
-
-        skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-division> ;
-    skos:definition "Requirement Class: LandVision" ;
+    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-division> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
+    skos:definition "Land can be divided up into land divisions.  These can either be public (political, judicial, or executive) or private in nature.  The former are administrative divisions and the latter are interests in land.  Both of these are specified in the LandDivision Requirements Class, though condominium interests in land are specified in a separate, Condominium Requirements Class." ;
     skos:prefLabel "Requirement Class: LandVision" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/land-division/classes> a spec:Requirement,
@@ -757,9 +760,9 @@ manner as is consistent with the encoding.""" ;
 <http://www.opengis.net/spec/landinfra/1.0/req/observations> a spec:RequirementClass,
         skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/observations/classes> ;
-
-        skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/observations> ;
-    skos:definition "Requirement Class: Observations" ;
+    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/observations> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/survey> ;
+    skos:definition "Observations Requirements class is the package containing all information about the raw observations and the measurements observed during survey work. The raw observations are needed to enable later reprocessing or reporting of resulting properties of the observed feature of interest." ;
     skos:prefLabel "Requirement Class: Observations" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/observations/classes> a spec:Requirement,
@@ -861,10 +864,11 @@ provided for by the encoding in a manner consistent with the encoding.""" ;
 <http://www.opengis.net/spec/landinfra/1.0/conf/project> a spec:ConformanceClass,
         skos:Concept ;
     spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/project/classes> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    #skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
     skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/project> ;
 
-    skos:definition "Conformance Class: Project" ;
+    skos:definition "A project is an activity related to the improvement of a facility, including design and/or construction.  This class may be for the creation, modification, or elimination of the entire facility or a part of the facility.  The Project Requirements Class includes information about projects and their decomposition into project parts.  In order to allow for the condition where none of the LandInfra dataset information is project related, this Requirements Class is optional." ;
     skos:prefLabel "Conformance Class: Project" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/equipment> a spec:RequirementClass,
@@ -873,7 +877,8 @@ provided for by the encoding in a manner consistent with the encoding.""" ;
         <http://www.opengis.net/spec/landinfra/1.0/req/equipment/observation-correction> ;
 
     skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/equipment> ;
-    skos:definition "Requirement Class: Equipment" ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/survey> ;
+    skos:definition "In the Equipment Requirements class all information about the processes and the sensors is available that had been used for the determination of an observation." ;
     skos:prefLabel "Requirement Class: Equipment" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/land-feature> a spec:RequirementClass,
@@ -881,25 +886,27 @@ provided for by the encoding in a manner consistent with the encoding.""" ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/land-feature/alignment>,
         <http://www.opengis.net/spec/landinfra/1.0/req/land-feature/classes> ;
 
-      skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature> ;
-    skos:definition "Requirement Class: LandFeature" ;
+    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
+    skos:definition "Features of the land, such as naturally occurring water features and vegetation are specified in the LandFeature Requirements Class as land features.  Also included are models of the land surface and subsurface layers.  Improvements to the land such as the construction of an embankment or the planting of landscape material are considered to be part of Site Facilities in the Facility Requirements Class." ;
     skos:prefLabel "Requirement Class: LandFeature" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/project> a spec:RequirementClass,
         skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/project/classes> ;
 
-        skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/project> ;
-    skos:definition "Requirement Class: Project" ;
+    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/project> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/facility> ;
+    skos:definition "Facilities include collections of buildings and civil engineering works and their associated siteworks.  The Facilities Requirements Class includes the breakdown of facilities into discipline specific facility parts and introduces the notion of elements which make up these parts.  The Facilities Requirements Class only provides general support for facilities themselves, allowing subsequent Requirements Classes to focus on specific types of the parts that make up facilities, such as road and railway.  This Requirements Class is optional in order to allow for the condition where all of the LandInfra dataset information is not facility related, such as one containing only survey or land division information." ;
     skos:prefLabel "Requirement Class: Project" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section> a spec:RequirementClass,
         skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/alignment>,
         <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/classes> ;
-
-        skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section> ;
-    skos:definition "Requirement Class: RoadCrossSection" ;
+    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/road> ;
+    skos:definition "The RoadCrossSection Requirements Class extends the Road Requirements Class by adding the 2D CrossSection alternative way of representing a design, as well as collections of these." ;
     skos:prefLabel "Requirement Class: RoadCrossSection" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/alignment> a spec:Requirement,
@@ -933,8 +940,9 @@ encoding.""" ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/survey-results/classes>,
         <http://www.opengis.net/spec/landinfra/1.0/req/survey-results/topic-20> ;
 
-           skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results> ;
-    skos:definition "Requirement Class: SurveyResult" ;
+    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/survey> ;
+    skos:definition "The SurveyResults Requirements Class contains the observed property of a feature of interest.  Using sampling features from the Observation & Measurements (O&M) standard, the dependencies between the observation acts and the results are realized." ;
     skos:prefLabel "Requirement Class: SurveyResult" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/survey-results/classes> a spec:Requirement,
@@ -968,7 +976,8 @@ appropriate requirements classes accordingly.""" ;
         <http://www.opengis.net/spec/landinfra/1.0/req/railway/classes> ;
 
     skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/railway> ;
-    skos:definition "Requirement Class: Railway" ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/facility> ;
+    skos:definition "The Railway Requirements Class supports those use cases where a designer wishes to exchange the output of the railway design with someone who is likely to use if for purposes other than further design. Consequently, the Railway Requirements Class covers design output such as 3D railway elements and track geometry including superelevation (cant)." ;
     skos:prefLabel "Requirement Class: Railway" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/survey> a spec:RequirementClass,
@@ -978,17 +987,18 @@ appropriate requirements classes accordingly.""" ;
         <http://www.opengis.net/spec/landinfra/1.0/req/survey/classes> ;
 
         skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/survey> ;
-    skos:definition "Requirement Class: Survey" ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
+    skos:definition "The Survey Requirements Class is the main survey class and provides a framework for information about observations, processes and their results collected during survey work. The content of this package is similar to the OGC Sensor Model Language (SensorML). The main reason not to use the SensorML standard for this topic is to allow the observation and processes structured in a compact way similar to the LandXML format. Due to the high number of classes the Survey Package was split into different parts, Equipment, Observations and SurveyResults." ;
     skos:prefLabel "Requirement Class: Survey" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/facility> a spec:ConformanceClass,
         skos:Concept ;
     spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/facility/classes>,
         <http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    #skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
     skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/facility> ;
-
-    skos:definition "Conformance Class: Facility" ;
+    skos:definition "Facilities include collections of buildings and civil engineering works and their associated siteworks.  The Facilities Requirements Class includes the breakdown of facilities into discipline specific facility parts and introduces the notion of elements which make up these parts.  The Facilities Requirements Class only provides general support for facilities themselves, allowing subsequent Requirements Classes to focus on specific types of the parts that make up facilities, such as road and railway.  This Requirements Class is optional in order to allow for the condition where all of the LandInfra dataset information is not facility related, such as one containing only survey or land division information." ;
     skos:prefLabel "Conformance Class: Facility" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/facility> a spec:RequirementClass,
@@ -996,8 +1006,9 @@ appropriate requirements classes accordingly.""" ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/facility/classes>,
         <http://www.opengis.net/spec/landinfra/1.0/req/facility/subtypes> ;
 
-        skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
-    skos:definition "Requirement Class: Facility" ;
+    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
+    skos:definition "Facilities include collections of buildings and civil engineering works and their associated siteworks.  The Facilities Requirements Class includes the breakdown of facilities into discipline specific facility parts and introduces the notion of elements which make up these parts.  The Facilities Requirements Class only provides general support for facilities themselves, allowing subsequent Requirements Classes to focus on specific types of the parts that make up facilities, such as road and railway.  This Requirements Class is optional in order to allow for the condition where all of the LandInfra dataset information is not facility related, such as one containing only survey or land division information." ;
     skos:prefLabel "Requirement Class: Facility" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/road> a spec:RequirementClass,
@@ -1007,8 +1018,9 @@ appropriate requirements classes accordingly.""" ;
         <http://www.opengis.net/spec/landinfra/1.0/req/road/alignment>,
         <http://www.opengis.net/spec/landinfra/1.0/req/road/classes> ;
 
-        skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/road> ;
-    skos:definition "Requirement Class: Road" ;
+    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/road> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/facility> ;
+    skos:definition "The Road Requirements Class supports those use cases in which a designer wishes to exchange the output of the design with someone who is likely to use it for purposes other than completing the road design.  Consequently, the Road Requirements Class includes several alternative ways for representing a design such as with 3D RoadElements, 3D StringLines (aka profile views, longitudinal breaklines, long sections), and 3D surfaces and layers, as well as collections of these. " ;
     skos:prefLabel "Requirement Class: Road" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/alignment> a spec:RequirementClass,
@@ -1020,7 +1032,9 @@ appropriate requirements classes accordingly.""" ;
         <http://www.opengis.net/spec/landinfra/1.0/req/alignment/measures> ;
 
     skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
-    skos:definition "Requirement Class: Alignment" ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/facility> ;
+    skos:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
+    skos:definition "An alignment is a positioning element which provides a Linear Referencing System for locating physical elements.  The Alignment Requirements Class specifies how an alignment is defined and used." ;
     skos:prefLabel "Requirement Class: Alignment" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> a spec:ConformanceClass,
@@ -1037,7 +1051,7 @@ appropriate requirements classes accordingly.""" ;
         <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-extensions> ;
     skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
     skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
-    skos:definition "Core Conformance Class: LandInfra" ;
+    skos:definition "LandInfra is the core Requirements Class and is the only mandatory Requirements Class.  This class contains information about the Land and Infrastructure dataset that can contain information about facilities, land features, land division, documents, survey marks, surveys, sets, and feature associations.  LandInfra also contains the definition of types common across other Requirements Classes, such as the Status CodeList." ;
 
     skos:prefLabel "Core Conformance Class: LandInfra" .
 
@@ -1054,8 +1068,9 @@ appropriate requirements classes accordingly.""" ;
         <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-core>,
         <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-extensions> ;
 
+    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
     skos:definition "Requirement Class: LandInfra" ;
-        skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
+    spec:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
     skos:prefLabel "Requirement Class: LandInfra" .
 
 <http://www.opengis.net/def/docs/15-111r1> a spec:Specification ;

--- a/specification-elements/defs/15-111r1.txt
+++ b/specification-elements/defs/15-111r1.txt
@@ -1,12 +1,18 @@
 Validation Report
 Conforms: False
-Results (4):
+Results (5):
 Constraint Violation in MinCountConstraintComponent (http://www.w3.org/ns/shacl#MinCountConstraintComponent):
 	Severity: sh:Violation
 	Source Shape: [ sh:minCount Literal("1", datatype=xsd:integer) ; sh:or ( [ sh:datatype xsd:string ] [ sh:datatype rdf:langString ] ) ; sh:path <http://www.w3.org/2004/02/skos/core#prefLabel> ; sh:uniqueLang Literal("true" = True, datatype=xsd:boolean) ]
 	Focus Node: <http://www.opengis.net/spec/landinfra/1.0/>
 	Result Path: <http://www.w3.org/2004/02/skos/core#prefLabel>
 	Message: Less than 1 values on <http://www.opengis.net/spec/landinfra/1.0/>-><http://www.w3.org/2004/02/skos/core#prefLabel>
+Constraint Violation in OrConstraintComponent (http://www.w3.org/ns/shacl#OrConstraintComponent):
+	Severity: sh:Violation
+	Source Shape: <https://w3id.org/profile/vocpub/shapes/Requirement-2.3.3>
+	Focus Node: <http://www.opengis.net/def/docs/15-111r1>
+	Value Node: <http://www.opengis.net/def/docs/15-111r1>
+	Message: Requirement 2.3.3 Each skos:Concept in a vocabulary _MUST_ indicate that it appears within that vocabulary's hierarchy of terms by use of either or both `skos:inScheme` and `skos:topConceptOf` properties
 Constraint Violation in ClassConstraintComponent (http://www.w3.org/ns/shacl#ClassConstraintComponent):
 	Severity: sh:Violation
 	Source Shape: <http://www.opengis.net/def/ont/modspec/Specification-modspec_status>
@@ -14,15 +20,15 @@ Constraint Violation in ClassConstraintComponent (http://www.w3.org/ns/shacl#Cla
 	Value Node: status:valid
 	Result Path: <http://www.opengis.net/def/ont/modspec/status>
 	Message: Value does not have class <http://www.opengis.net/def/ont/modspec/Status>
+Constraint Violation in ClassConstraintComponent (http://www.w3.org/ns/shacl#ClassConstraintComponent):
+	Severity: sh:Violation
+	Source Shape: <http://www.opengis.net/def/ont/modspec/requirementsTested-shape>
+	Focus Node: <http://www.opengis.net/spec/landinfra/1.0/req/land-infra>
+	Value Node: <http://www.opengis.net/spec/landinfra/1.0/req/land-infra>
+	Message: Value does not have class <http://www.opengis.net/def/ont/modspec/ConformanceClass>
 Constraint Violation in MaxCountConstraintComponent (http://www.w3.org/ns/shacl#MaxCountConstraintComponent):
 	Severity: sh:Violation
 	Source Shape: [ sh:maxCount Literal("1", datatype=xsd:integer) ; sh:message Literal("Requirement 2.1.2 Each vocabulary _MUST_ be presented as a single skos:ConceptScheme object & Requirment 2.1.3 Each vocabulary MUST be presented in a single file which does not contain information other than that which is directly part of the vocabulary and the file is considered the point-of-truth") ; sh:minCount Literal("1", datatype=xsd:integer) ; sh:path [ sh:inversePath rdf:type ] ]
 	Focus Node: skos:ConceptScheme
 	Result Path: [ sh:inversePath rdf:type ]
 	Message: Requirement 2.1.2 Each vocabulary _MUST_ be presented as a single skos:ConceptScheme object & Requirment 2.1.3 Each vocabulary MUST be presented in a single file which does not contain information other than that which is directly part of the vocabulary and the file is considered the point-of-truth
-Constraint Violation in OrConstraintComponent (http://www.w3.org/ns/shacl#OrConstraintComponent):
-	Severity: sh:Violation
-	Source Shape: <https://w3id.org/profile/vocpub/shapes/Requirement-2.3.3>
-	Focus Node: <http://www.opengis.net/def/docs/15-111r1>
-	Value Node: <http://www.opengis.net/def/docs/15-111r1>
-	Message: Requirement 2.3.3 Each skos:Concept in a vocabulary _MUST_ indicate that it appears within that vocabulary's hierarchy of terms by use of either or both `skos:inScheme` and `skos:topConceptOf` properties

--- a/specification-elements/defs/entailed/landinfra/1.0.rdf
+++ b/specification-elements/defs/entailed/landinfra/1.0.rdf
@@ -15,1624 +15,1596 @@
    xmlns:spec="http://www.opengis.net/def/ont/modspec/"
    xmlns:specrel="http://www.opengis.net/def/ont/specrel/"
 >
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/LR-interfaces">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding implements the OGC Abstract Specification Topic 19 ILinearElement and ISpatial interfaces in a manner consistent with the encoding.</spec:purpose>
-    <skos:definition>Verify that the encoding implements the OGC Abstract Specification Topic 19 ILinearElement and ISpatial interfaces in a manner consistent with the encoding.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/LR-interfaces"/>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/observations/classes">
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/observations"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/observations/classes</skos:prefLabel>
+    <skos:definition>Verify that the encoding provides the Observation Requirements Class Classes shown in blue in Figure 43 in a manner consistent with the encoding.  An encoding shall decide which SurveyObservation types it will support and define appropriate requirements classes accordingly. This then would include any dependent types (example SatelliteSystemType has only to be supported if the encoding will support GNSS Observations).</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/observations/classes"/>
     <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/LR-interfaces</skos:prefLabel>
     <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/def/status/deprecated">
-    <skos:definition xml:lang="en">An entry that has been retired or replaced and is no longer to be used.</skos:definition>
-    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
-    <skos:prefLabel xml:lang="en">deprecated</skos:prefLabel>
-    <skos:broader rdf:resource="http://www.opengis.net/def/status/accepted"/>
-    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
-    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusDeprecated"/>
-    <dct:source rdf:resource="http://purl.org/linked-data/registry#"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/def/status/superseded"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/def/status/retired"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/observations/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>The Observations Requirements Class Classes shown in blue in Figure 41Figure
-43 shall be provided for by the encoding in a manner consistent with the
-encoding. An encoding shall decide which SurveyObservation types it will
-support and define appropriate requirements classes accordingly. This then
-would include any dependent types (example SatelliteSystemType has only to be
-supported if the encoding will support GNSS Observations).</dct:description>
-    <skos:definition>The Observations Requirements Class Classes shown in blue in Figure 41Figure
-43 shall be provided for by the encoding in a manner consistent with the
-encoding. An encoding shall decide which SurveyObservation types it will
-support and define appropriate requirements classes accordingly. This then
-would include any dependent types (example SatelliteSystemType has only to be
-supported if the encoding will support GNSS Observations).</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/observations"/>
-    <skos:prefLabel>Requirement: /req/observations/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-division/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding provides the LandDivision Requirements Class Classes shown in blue in Figure 60 in a manner consistent with the encoding.</spec:purpose>
-    <skos:definition>Verify that the encoding provides the LandDivision Requirements Class Classes shown in blue in Figure 60 in a manner consistent with the encoding.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-division/classes"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-division"/>
-    <skos:prefLabel>ConformanceTest: http://www.opengis.net/spec/landinfra/1.0/conf/land-division/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/railway">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway/alignment"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway/cant"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway/classes"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway"/>
-    <skos:definition>Requirement Class: Railway</skos:definition>
-    <skos:prefLabel>Requirement Class: Railway</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway/classes"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway/cant"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway/alignment"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/road/alignment">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>If an encoding allows the linear element used for locating RoadElements to be
-an Alignment, then that encoding shall support the Alignment Requirements
-Class.</dct:description>
-    <skos:definition>If an encoding allows the linear element used for locating RoadElements to be
-an Alignment, then that encoding shall support the Alignment Requirements
-Class.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road"/>
-    <skos:prefLabel>Requirement: /req/road/alignment</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/equipment">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment/classes"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment/observation-correction"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/equipment"/>
-    <skos:definition>Requirement Class: Equipment</skos:definition>
-    <skos:prefLabel>Requirement Class: Equipment</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment/observation-correction"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment/classes"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/classes">
     <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <spec:purpose>Verify that the encoding provides the Observation Requirements Class Classes shown in blue in Figure 43 in a manner consistent with the encoding.  An encoding shall decide which SurveyObservation types it will support and define appropriate requirements classes accordingly. This then would include any dependent types (example SatelliteSystemType has only to be supported if the encoding will support GNSS Observations).</spec:purpose>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>If an encoding includes Alignments, then verify that the encoding provides the Alignment Requirements Class Classes shown in blue in Figure 15 in a manner consistent with the encoding.</spec:purpose>
-    <skos:definition>If an encoding includes Alignments, then verify that the encoding provides the Alignment Requirements Class Classes shown in blue in Figure 15 in a manner consistent with the encoding.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/classes"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/project/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:dependency rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/facility"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding provides the Project Requirements Class Classes shown in blue in Figure 13 in a manner consistent with the encoding.</spec:purpose>
-    <skos:definition>Verify that the encoding provides the Project Requirements Class Classes shown in blue in Figure 13 in a manner consistent with the encoding.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/project/classes"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/project"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/project/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/condominium">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/condominium/classes"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/condominium"/>
-    <skos:definition>Requirement Class: Condominium</skos:definition>
-    <skos:prefLabel>Requirement Class: Condominium</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/condominium/classes"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/survey-results">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/classes"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/topic-20"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results"/>
-    <skos:definition>Requirement Class: SurveyResult</skos:definition>
-    <skos:prefLabel>Requirement Class: SurveyResult</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/topic-20"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/classes"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/featureID">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding specifies whether it supports ID at the feature level, ID at the Feature sub-type level, or both.</spec:purpose>
-    <skos:definition>Verify that the encoding specifies whether it supports ID at the feature level, ID at the Feature sub-type level, or both.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/featureID"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/featureID</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/crs">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>An encoding shall support coordinate reference systems in accordance with OGC Abstract Specification Topic 2, Spatial Referencing by Coordinates.</dct:description>
-    <skos:definition>An encoding shall support coordinate reference systems in accordance with OGC Abstract Specification Topic 2, Spatial Referencing by Coordinates.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
-    <skos:prefLabel>Requirement: /req/land-infra/crs</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/def/status/iso19135">
-    <skos:definition xml:lang="en">Register Item status values according to ISO19135.</skos:definition>
-    <skos:member rdf:resource="http://www.opengis.net/def/status/superseded"/>
-    <skos:member rdf:resource="http://www.opengis.net/def/status/retired"/>
-    <skos:member rdf:resource="http://www.opengis.net/def/status/invalid"/>
-    <skos:member rdf:resource="http://www.opengis.net/def/status/valid"/>
-    <skos:member rdf:resource="http://www.opengis.net/def/status/submitted"/>
-    <skos:prefLabel xml:lang="en">ISO 19135 Register Item status values</skos:prefLabel>
-    <dct:source rdf:resource="https://def.isotc211.org/iso19135/-1/2015/CoreModel.rdf"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Collection"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/def/status/notAccepted">
-    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusNotAccepted"/>
-    <skos:definition xml:lang="en">An entry that should not be visible in the default register listing. Corresponds to ISO 19135:2005 'notValid'.</skos:definition>
-    <dct:source rdf:resource="http://purl.org/linked-data/registry#"/>
-    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
-    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
-    <skos:prefLabel xml:lang="en">not accepted</skos:prefLabel>
-    <skos:topConceptOf rdf:resource="http://www.opengis.net/def/status"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/def/status/submitted"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/def/status/reserved"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/def/status/under-development"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/def/status/invalid"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/topic-20">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that, if the encoding supports survey results subjects, then the encoding shall support the SF_SamplingFeature and related Classes specified in the OGC Abstract Specification Topic 20, Observation and Measurements shown in Figure 54 that are appropriate to the supported subject area(s).</spec:purpose>
-    <skos:definition>Verify that, if the encoding supports survey results subjects, then the encoding shall support the SF_SamplingFeature and related Classes specified in the OGC Abstract Specification Topic 20, Observation and Measurements shown in Figure 54 that are appropriate to the supported subject area(s).</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/topic-20"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/topic-20</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/road/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding provides the Road Requirements Class Classes shown in blue in Figure 21 in a manner consistent with the encoding.</spec:purpose>
-    <skos:definition>Verify that the encoding provides the Road Requirements Class Classes shown in blue in Figure 21 in a manner consistent with the encoding.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road/classes"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/road/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>If an encoding allows the linear element used for a LandLayer to be an Alignment, then verify that the encoding supports the Alignment Requirements class.</spec:purpose>
-    <skos:definition>If an encoding allows the linear element used for a LandLayer to be an Alignment, then verify that the encoding supports the Alignment Requirements class.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature/alignment"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
-    <dct:source rdf:resource="http://www.opengis.net/def/docs/15-111r1"/>
-    <skos:prefLabel>Specification elements for OGC 15-111r LandInfra</skos:prefLabel>
-    <skos:definition>A convenience hierarchy for navigating the elements of a specification using the SKOS model</skos:definition>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2016-12-20</dct:modified>
-    <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2016-12-20</dct:created>
-    <skos:hasTopConcept rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment"/>
-    <skos:hasTopConcept rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/condominium"/>
-    <skos:hasTopConcept rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/equipment"/>
-    <skos:hasTopConcept rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-division"/>
-    <skos:hasTopConcept rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature"/>
-    <skos:hasTopConcept rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/observations"/>
-    <skos:hasTopConcept rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway"/>
-    <skos:hasTopConcept rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road"/>
-    <skos:hasTopConcept rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section"/>
-    <skos:hasTopConcept rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey"/>
-    <skos:hasTopConcept rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results"/>
-    <skos:hasTopConcept rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/project"/>
-    <skos:hasTopConcept rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/facility"/>
-    <skos:hasTopConcept rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
-    <spec:status rdf:resource="http://www.opengis.net/def/status/experimental"/>
-    <na:status rdf:resource="http://www.opengis.net/def/status/experimental"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19109">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that Features shall be supported by a Land and Infrastructure encoding in accordance with the uml:feature requirement in ISO 19109:2015 Clause 8.2.6 and shown in Figure 9, as follows:   Each instance of FeatureType shall be implemented by the encoding’s equivalent of a UML Class having a generalization association with AnyFeature and with a stereotype of &lt;&lt;FeatureType&gt;&gt;.</spec:purpose>
-    <skos:definition>Verify that Features shall be supported by a Land and Infrastructure encoding in accordance with the uml:feature requirement in ISO 19109:2015 Clause 8.2.6 and shown in Figure 9, as follows:   Each instance of FeatureType shall be implemented by the encoding’s equivalent of a UML Class having a generalization association with AnyFeature and with a stereotype of &lt;&lt;FeatureType&gt;&gt;.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19109"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19109</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding provides the SurveyResults Requirements Class Classes shown in blue in Figure 52 in a manner consistent with the encoding.  An encoding shall decide which SurveyResult types it will support and define appropriate requirements classes accordingly.</spec:purpose>
-    <skos:definition>Verify that the encoding provides the SurveyResults Requirements Class Classes shown in blue in Figure 52 in a manner consistent with the encoding.  An encoding shall decide which SurveyResult types it will support and define appropriate requirements classes accordingly.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/classes"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/facility/subtypes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>A Land and Infrastructure encoding shall specify which of the FacilityPart subtypes shown in Figure 10 it supports.</dct:description>
-    <skos:definition>A Land and Infrastructure encoding shall specify which of the FacilityPart subtypes shown in Figure 10 it supports.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility"/>
-    <skos:prefLabel>Requirement: /req/facility/subtypes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding provides the LandFeature Requirements Class Classes shown in blue in Figure 55 in a manner consistent with the encoding.</spec:purpose>
-    <skos:definition>Verify that the encoding provides the LandFeature Requirements Class Classes shown in blue in Figure 55 in a manner consistent with the encoding.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature/classes"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature"/>
-    <skos:prefLabel>ConformanceTest: http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/railway/cant">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>An encoding shall specify as a requirement that each CantSpecification shall
-cover the entire linear element the CantSpecification is located along from
-the linear element’s start to its end, and that the CantSpecification shall
-include CantEvents at the start and end of the linear element and wherever
-else there is a cant break along the linear element.</dct:description>
-    <skos:definition>An encoding shall specify as a requirement that each CantSpecification shall
-cover the entire linear element the CantSpecification is located along from
-the linear element’s start to its end, and that the CantSpecification shall
-include CantEvents at the start and end of the linear element and wherever
-else there is a cant break along the linear element.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway"/>
-    <skos:prefLabel>Requirement: /req/railway/cant</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/condominium/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>The Condominium Requirements Class Classes shown in blue in Figure 68 shall be provided for by the encoding in a manner consistent with the encoding.</dct:description>
-    <skos:definition>The Condominium Requirements Class Classes shown in blue in Figure 68 shall be provided for by the encoding in a manner consistent with the encoding.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/condominium"/>
-    <skos:prefLabel>Requirement: /req/condominium/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/equipment/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>The Equipment Requirements Class Classes shown in blue in Figure 48 shall be provided for by the encoding in a manner consistent with the encoding. An encoding shall decide which SurveySensor types it will support and define appropriate requirements classes accordingly.</dct:description>
-    <skos:definition>The Equipment Requirements Class Classes shown in blue in Figure 48 shall be provided for by the encoding in a manner consistent with the encoding. An encoding shall decide which SurveySensor types it will support and define appropriate requirements classes accordingly.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment"/>
-    <skos:prefLabel>Requirement: /req/equipment/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.opengis.net/def/ont/modspec_validations">
     <ns1:title>The Specification Model — A Standard for Modular specifications</ns1:title>
-    <dct:modified>2015-06-10</dct:modified>
-    <ns1:source>The Specification Model — A Standard for Modular specifications. OGC document 08-131r3 https://portal.opengeospatial.org/files/34762</ns1:source>
     <skos:prefLabel>An RDF/OWL ontology for modular specifications</skos:prefLabel>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
-    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/doc/modular-spec"/>
-    <ns1:rights>Copyright © 2021 Open Geospatial Consortium. To obtain additional rights of use, visit http://www.opengeospatial.org/legal/</ns1:rights>
-    <rdfs:comment>Needed until pySHACL can be told to use core model without trying to validate it all against a different set of rules</rdfs:comment>
     <ns1:description>Minimal validation helpers for instances of the Modspec ontology.</ns1:description>
+    <rdfs:comment>Needed until pySHACL can be told to use core model without trying to validate it all against a different set of rules</rdfs:comment>
+    <dct:modified>2015-06-10</dct:modified>
+    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/doc/modular-spec"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
     <ns1:creator>Rob Atkinson</ns1:creator>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19109">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>Features shall be supported by a Land and Infrastructure encoding in accordance with the uml:feature requirement in ISO 19109:2015 Clause 8.2.6 and shown in Figure 9, as follows: Each instance of FeatureType shall be implemented by the encoding’s equivalent of a UML Class having a generalization association with AnyFeature and with a stereotype of &lt;&gt;.</dct:description>
-    <skos:definition>Features shall be supported by a Land and Infrastructure encoding in accordance with the uml:feature requirement in ISO 19109:2015 Clause 8.2.6 and shown in Figure 9, as follows: Each instance of FeatureType shall be implemented by the encoding’s equivalent of a UML Class having a generalization association with AnyFeature and with a stereotype of &lt;&gt;.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
-    <skos:prefLabel>Requirement: /req/land-infra/19109</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/alignment/LR-interfaces">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>An encoding shall implement the OGC Abstract Specification Topic 19 ILinearElement and ISpatial interfaces in a manner consistent with the encoding.</dct:description>
-    <skos:definition>An encoding shall implement the OGC Abstract Specification Topic 19 ILinearElement and ISpatial interfaces in a manner consistent with the encoding.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment"/>
-    <skos:prefLabel>Requirement: /req/alignment/LR-interfaces</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-feature/alignment">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>If an encoding allows the linear element used for a LandLayer to be an Alignment, then that encoding shall support the Alignment Requirements Class.</dct:description>
-    <skos:definition>If an encoding allows the linear element used for a LandLayer to be an Alignment, then that encoding shall support the Alignment Requirements Class.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature"/>
-    <skos:prefLabel>Requirement: /req/land-feature/alignment</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/survey">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey/classes"/>
-    <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey"/>
-    <skos:definition>Conformance Class: Survey</skos:definition>
-    <skos:prefLabel>Conformance Class: Survey</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey/classes"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/road">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road/classes"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road/alignment"/>
-    <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road"/>
-    <skos:definition>Conformance Class: Road</skos:definition>
-    <skos:prefLabel>Conformance Class: Road</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road/alignment"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road/classes"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <ns1:rights>Copyright © 2021 Open Geospatial Consortium. To obtain additional rights of use, visit http://www.opengeospatial.org/legal/</ns1:rights>
+    <ns1:source>The Specification Model — A Standard for Modular specifications. OGC document 08-131r3 https://portal.opengeospatial.org/files/34762</ns1:source>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/alignment">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
     <spec:purpose>Verify that if the encoding allows the linear element used for locating CrossSections to be an Alignment, then that encoding supports the Alignment Requirements Class.</spec:purpose>
-    <skos:definition>Verify that if the encoding allows the linear element used for locating CrossSections to be an Alignment, then that encoding supports the Alignment Requirements Class.</skos:definition>
     <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/alignment"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section"/>
     <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/alignment</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/survey">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/classes"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/topic-20"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey/classes"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey"/>
-    <skos:definition>Requirement Class: Survey</skos:definition>
-    <skos:prefLabel>Requirement Class: Survey</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/topic-20"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey/classes"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/classes"/>
+    <skos:definition>Verify that if the encoding allows the linear element used for locating CrossSections to be an Alignment, then that encoding supports the Alignment Requirements Class.</skos:definition>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra">
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/subjects">
+    <skos:definition>Verify that the encoding specifies which of the LandInfra subjects it supports.</skos:definition>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <spec:purpose>Verify that the encoding specifies which of the LandInfra subjects it supports.</spec:purpose>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/subjects</skos:prefLabel>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/subjects"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/description">
+    <spec:purpose>Verify that an encoding which includes Alignments shall specify that all of the included Alignments shall be continuous, non-overlapping, and non-branching (though it may contain intersections with other Alignments) and that if it is used within the context of a Project, the included Alignment shall be for a single alternative, as specified by the ProjectPart.</spec:purpose>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/description"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <skos:definition>Verify that an encoding which includes Alignments shall specify that all of the included Alignments shall be continuous, non-overlapping, and non-branching (though it may contain intersections with other Alignments) and that if it is used within the context of a Project, the included Alignment shall be for a single alternative, as specified by the ProjectPart.</skos:definition>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/description</skos:prefLabel>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/road">
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/classes"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road/alignment"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/alignment"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road/classes"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/alignment"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road/classes"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/classes"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road/alignment"/>
+    <skos:definition>Requirement Class: Road</skos:definition>
+    <skos:prefLabel>Requirement Class: Road</skos:prefLabel>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment">
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <skos:definition>If an encoding allows the linear element used for a LandLayer to be an Alignment, then verify that the encoding supports the Alignment Requirements class.</skos:definition>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <spec:purpose>If an encoding allows the linear element used for a LandLayer to be an Alignment, then verify that the encoding supports the Alignment Requirements class.</spec:purpose>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature/alignment"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment</skos:prefLabel>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section">
+    <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
     <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19103"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19109"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/classes"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/crs"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/dataset"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/featureID"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/subjects"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-1"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-core"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-extensions"/>
-    <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
-    <skos:definition>Core Conformance Class: LandInfra</skos:definition>
-    <skos:prefLabel>Core Conformance Class: LandInfra</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/subjects"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-extensions"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/featureID"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-core"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19103"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/crs"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-1"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19109"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/dataset"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/classes"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:prefLabel>Conformance Class: RoadCrossSection</skos:prefLabel>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/measures">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>If an encoding uses Alignment as a linear element, verify that it specifies that:
-1) If an Alignment2DHorizontal.2DLinestringRepresentation or an Alignment3D.3DLinestringRepresentation is specified as a linear element, then distanceAlong shall be measured along the LineString and offsetLateralDistance and offsetVerticalDistance values shall be measured normal to the LineString from this DistanceAlong point.
-2) If an Alignment2DHorizontal.segment list of Alignment2DHorSegments is used as a linear element, then distanceAlong and offsetLateralDistance values shall be measured in the horizontal plane, ignoring any vertical displacement of the Alignment.  OffsetVerticalDistance values shall be absolute from the horizontal plane unless an Alignment2DVertical is specified as a VerticalOffsetReferent so as to take into consideration vertical displacement of the Alignment, if present.</spec:purpose>
-    <skos:definition>If an encoding uses Alignment as a linear element, verify that it specifies that:
-1) If an Alignment2DHorizontal.2DLinestringRepresentation or an Alignment3D.3DLinestringRepresentation is specified as a linear element, then distanceAlong shall be measured along the LineString and offsetLateralDistance and offsetVerticalDistance values shall be measured normal to the LineString from this DistanceAlong point.
-2) If an Alignment2DHorizontal.segment list of Alignment2DHorSegments is used as a linear element, then distanceAlong and offsetLateralDistance values shall be measured in the horizontal plane, ignoring any vertical displacement of the Alignment.  OffsetVerticalDistance values shall be absolute from the horizontal plane unless an Alignment2DVertical is specified as a VerticalOffsetReferent so as to take into consideration vertical displacement of the Alignment, if present.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/measures"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/measures</skos:prefLabel>
     <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section"/>
+    <skos:definition>The RoadCrossSection Requirements Class extends the Road Requirements Class by adding the 2D CrossSection alternative way of representing a design, as well as collections of these.</skos:definition>
+    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/alignment"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/alignment"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/classes"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/classes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/condominium/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding provides the Condominium Requirements Class Classes shown in blue in Figure 68 in a manner consistent with the encoding.</spec:purpose>
-    <skos:definition>Verify that the encoding provides the Condominium Requirements Class Classes shown in blue in Figure 68 in a manner consistent with the encoding.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/condominium/classes"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/condominium"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/condominium/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/alignment/CRS">
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/railway/alignment">
     <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>All geometry/locations for Alignment2DHorSegments and Alignment2DVertSegments shall be specified using the Alignment2DHorizontal.crs which shall be a Cartesian local engineering reference system.</dct:description>
-    <skos:definition>All geometry/locations for Alignment2DHorSegments and Alignment2DVertSegments shall be specified using the Alignment2DHorizontal.crs which shall be a Cartesian local engineering reference system.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment"/>
-    <skos:prefLabel>Requirement: /req/alignment/CRS</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:prefLabel>Requirement: /req/railway/alignment</skos:prefLabel>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/equipment">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/equipment/classes"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/equipment/observation-correction"/>
-    <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:definition>Conformance Class: Equipment</skos:definition>
-    <skos:prefLabel>Conformance Class: Equipment</skos:prefLabel>
-    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/equipment/observation-correction"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/equipment/classes"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-feature">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature/alignment"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature/classes"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature"/>
-    <skos:definition>Requirement Class: LandFeature</skos:definition>
-    <skos:prefLabel>Requirement Class: LandFeature</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature/alignment"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature/classes"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <dct:description>If an encoding allows the linear element used for locating RailwayElements or
+CantEvents to be an Alignment, then that encoding shall support the Alignment
+Requirements Class.</dct:description>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway"/>
+    <skos:definition>If an encoding allows the linear element used for locating RailwayElements or
+CantEvents to be an Alignment, then that encoding shall support the Alignment
+Requirements Class.</skos:definition>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/survey/classes">
     <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/survey/classes</skos:prefLabel>
     <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
     <spec:purpose>Verify that the encoding provides the Survey Requirements Class Classes shown in blue in Figure 41 in a manner consistent with the encoding.</spec:purpose>
-    <skos:definition>Verify that the encoding provides the Survey Requirements Class Classes shown in blue in Figure 41 in a manner consistent with the encoding.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey/classes"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
     <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/survey/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey/classes"/>
+    <skos:definition>Verify that the encoding provides the Survey Requirements Class Classes shown in blue in Figure 41 in a manner consistent with the encoding.</skos:definition>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/alignment/description">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>An encoding which includes Alignments shall specify that all of the included Alignments shall be continuous, non-overlapping, and non-branching (though it may contain intersections with other Alignments) and that if it is used within the context of a Project, the included Alignment shall be for a single alternative, as specified by the ProjectPart.</dct:description>
-    <skos:definition>An encoding which includes Alignments shall specify that all of the included Alignments shall be continuous, non-overlapping, and non-branching (though it may contain intersections with other Alignments) and that if it is used within the context of a Project, the included Alignment shall be for a single alternative, as specified by the ProjectPart.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment"/>
-    <skos:prefLabel>Requirement: /req/alignment/description</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+  <rdf:Description rdf:about="http://www.opengis.net/def/status/experimental">
+    <skos:prefLabel xml:lang="en">experimental</skos:prefLabel>
+    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <dct:source rdf:resource="http://purl.org/linked-data/registry#"/>
+    <skos:definition xml:lang="en">An entry that has been accepted into the register temporarily and may be subject to change or withdrawal.</skos:definition>
+    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusExperimental"/>
+    <skos:broader rdf:resource="http://www.opengis.net/def/status/valid"/>
+    <skos:altlabel xml:lang="en">provisional</skos:altlabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/def/status/">
+    <skos:member rdf:resource="http://www.opengis.net/def/status/superseded"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:member rdf:resource="http://www.opengis.net/def/status/reserved"/>
+    <skos:member rdf:resource="http://www.opengis.net/def/status/deprecated"/>
+    <skos:definition xml:lang="en">Register Item statuses from ISO19135 and subsequent Linked Data Registry extensions.</skos:definition>
+    <skos:member rdf:resource="http://www.opengis.net/def/status/experimental"/>
+    <skos:member rdf:resource="http://www.opengis.net/def/status/stable"/>
+    <dct:provenance xml:lang="en">ISO19135 and subsequent Linked Data Registry extensions</dct:provenance>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:member rdf:resource="http://www.opengis.net/def/status/valid"/>
+    <skos:member rdf:resource="http://www.opengis.net/def/status/retired"/>
+    <skos:member rdf:resource="http://www.opengis.net/def/status/submitted"/>
+    <skos:member rdf:resource="http://www.opengis.net/def/status/invalid"/>
+    <skos:member rdf:resource="http://www.opengis.net/def/status/notAccepted"/>
+    <skos:prefLabel xml:lang="en">Register Item status values</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Collection"/>
+    <skos:member rdf:resource="http://www.opengis.net/def/status/accepted"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19103"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19109"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/classes"/>
     <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/crs"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/dataset"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/featureID"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/subjects"/>
     <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-1"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-core"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-extensions"/>
-    <skos:definition>Requirement Class: LandInfra</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
-    <skos:prefLabel>Requirement Class: LandInfra</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/crs"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/dataset"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
     <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/classes"/>
     <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/subjects"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/featureID"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-core"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-1"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-extensions"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19109"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
     <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19103"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-extensions"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/dataset"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/featureID"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/crs"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-1"/>
+    <skos:definition>Requirement Class: LandInfra</skos:definition>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19109"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-core"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/description">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/featureID"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19109"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/classes"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-core"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that an encoding which includes Alignments shall specify that all of the included Alignments shall be continuous, non-overlapping, and non-branching (though it may contain intersections with other Alignments) and that if it is used within the context of a Project, the included Alignment shall be for a single alternative, as specified by the ProjectPart.</spec:purpose>
-    <skos:definition>Verify that an encoding which includes Alignments shall specify that all of the included Alignments shall be continuous, non-overlapping, and non-branching (though it may contain intersections with other Alignments) and that if it is used within the context of a Project, the included Alignment shall be for a single alternative, as specified by the ProjectPart.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/description"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/description</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/subjects"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/dataset"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19103"/>
+    <skos:prefLabel>Requirement Class: LandInfra</skos:prefLabel>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-extensions"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/def/status/notAccepted">
+    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
+    <skos:prefLabel xml:lang="en">not accepted</skos:prefLabel>
+    <dct:source rdf:resource="http://purl.org/linked-data/registry#"/>
+    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusNotAccepted"/>
+    <skos:topConceptOf rdf:resource="http://www.opengis.net/def/status"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:definition xml:lang="en">An entry that should not be visible in the default register listing. Corresponds to ISO 19135:2005 'notValid'.</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/def/status/under-development"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/def/status/invalid"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/def/status/reserved"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/def/status/submitted"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/road/alignment">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/road/alignment</skos:prefLabel>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road/alignment"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:definition>Verify that if the encoding allows the linear element used for locating RoadElements to be an Alignment, then that encoding supports the Alignment Requirements Class.</skos:definition>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <spec:purpose>Verify that if the encoding allows the linear element used for locating RoadElements to be an Alignment, then that encoding supports the Alignment Requirements Class.</spec:purpose>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra">
+    <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:prefLabel>Core Conformance Class: LandInfra</skos:prefLabel>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-core"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/featureID"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19109"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/crs"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-extensions"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19103"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/dataset"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-1"/>
+    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/subjects"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/classes"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-core"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19109"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/featureID"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/dataset"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/crs"/>
+    <skos:definition>LandInfra is the core Requirements Class and is the only mandatory Requirements Class.  This class contains information about the Land and Infrastructure dataset that can contain information about facilities, land features, land division, documents, survey marks, surveys, sets, and feature associations.  LandInfra also contains the definition of types common across other Requirements Classes, such as the Status CodeList.</skos:definition>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19103"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-extensions"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/subjects"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-1"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/classes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/def/status/superseded">
+    <skos:altlabel xml:lang="en">replaced</skos:altlabel>
+    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusSuperceded"/>
+    <skos:broader rdf:resource="http://www.opengis.net/def/status/deprecated"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
+    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
+    <skos:prefLabel xml:lang="en">superseded</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:definition xml:lang="en">An entry that has been replaced by a new alternative which should be used instead.  Corresponds to ISO 19135:2005 'superseded'.</skos:definition>
+    <dct:source rdf:resource="https://def.isotc211.org/iso19135/-1/2015/catalog-v001.xml"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.opengis.net/def/docs/15-111r1">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Specification"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:creator>Paul Scarponcini</dct:creator>
-    <dct:dateAccepted rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2016-08-02</dct:dateAccepted>
-    <dct:dateSubmitted rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2016-05-16</dct:dateSubmitted>
-    <dct:identifier>http://www.opengis.net/doc/is/landinfra/1.0</dct:identifier>
-    <reg:status rdf:resource="http://purl.org/linked-data/registry#statusValid"/>
-    <spec:status rdf:resource="http://www.opengis.net/def/status/valid"/>
-    <na:doctype rdf:resource="http://www.opengis.net/def/doc-type/ip"/>
-    <spec:authority>Open Geospatial Consortium</spec:authority>
-    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment"/>
-    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/condominium"/>
-    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/equipment"/>
-    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/facility"/>
+    <spec:date rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2016-12-20</spec:date>
+    <adms:last rdf:resource="http://www.opengis.net/def/docs/15-111r1"/>
+    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road"/>
     <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-division"/>
     <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature"/>
-    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
-    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/observations"/>
-    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/project"/>
-    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway"/>
-    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road"/>
-    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section"/>
-    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey"/>
-    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results"/>
-    <spec:date rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2016-12-20</spec:date>
-    <specrel:implementation rdf:resource="http://www.opengis.net/def/docs/16-000r1"/>
-    <specrel:implementation rdf:resource="http://www.opengis.net/def/docs/16-100r2"/>
-    <specrel:implementation rdf:resource="http://www.opengis.net/def/docs/16-101r2"/>
-    <specrel:implementation rdf:resource="http://www.opengis.net/def/docs/16-102r2"/>
-    <specrel:implementation rdf:resource="http://www.opengis.net/def/docs/16-103r2"/>
-    <specrel:implementation rdf:resource="http://www.opengis.net/def/docs/16-104r2"/>
-    <specrel:implementation rdf:resource="http://www.opengis.net/def/docs/16-105r2"/>
-    <specrel:implementation rdf:resource="http://www.opengis.net/def/docs/16-106r2"/>
+    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/equipment"/>
+    <spec:status rdf:resource="http://www.opengis.net/def/status/valid"/>
     <specrel:implementation rdf:resource="http://www.opengis.net/def/docs/16-107r2"/>
-    <skos:notation rdf:datatype="http://www.opengis.net/def/metamodel/ogc-na/doc_no">15-111r1</skos:notation>
-    <skos:prefLabel>OGC® Land and Infrastructure Conceptual Model Standard (LandInfra)</skos:prefLabel>
-    <adms:version>1.0</adms:version>
-    <dcat:landingPage rdf:resource="http://docs.opengeospatial.org/is/15-111r1/15-111r1.html"/>
-    <adms:last rdf:resource="http://www.opengis.net/def/docs/15-111r1"/>
-    <prov:wasAttributedTo rdf:resource="http://www.opengis.net/def/wg/landinfraswg"/>
-    <na:status rdf:resource="http://www.opengis.net/def/status/valid"/>
+    <specrel:implementation rdf:resource="http://www.opengis.net/def/docs/16-104r2"/>
+    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/project"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/docs"/>
+    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
+    <reg:status rdf:resource="http://purl.org/linked-data/registry#statusValid"/>
+    <dcat:landingPage rdf:resource="http://docs.opengeospatial.org/is/15-111r1/15-111r1.html"/>
+    <specrel:implementation rdf:resource="http://www.opengis.net/def/docs/16-103r2"/>
+    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section"/>
+    <dct:identifier>http://www.opengis.net/doc/is/landinfra/1.0</dct:identifier>
+    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey"/>
+    <specrel:implementation rdf:resource="http://www.opengis.net/def/docs/16-000r1"/>
     <skos:definition>OGC® Land and Infrastructure Conceptual Model Standard (LandInfra)</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-extensions">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/observations"/>
+    <na:doctype rdf:resource="http://www.opengis.net/def/doc-type/ip"/>
+    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that, if the encoding supports linearly referenced locations, then the encoding specifies which of the OGC Abstract Specification Topic 19, Linear Referencing extension packages it supports and therefore supports the appropriate Classes shown in Figure 7 and Figure 8 for those packages that are appropriate to the supported subject area(s).</spec:purpose>
-    <skos:definition>Verify that, if the encoding supports linearly referenced locations, then the encoding specifies which of the OGC Abstract Specification Topic 19, Linear Referencing extension packages it supports and therefore supports the appropriate Classes shown in Figure 7 and Figure 8 for those packages that are appropriate to the supported subject area(s).</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-extensions"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-extensions</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <specrel:implementation rdf:resource="http://www.opengis.net/def/docs/16-102r2"/>
+    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/condominium"/>
+    <dct:creator>Paul Scarponcini</dct:creator>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Specification"/>
+    <specrel:implementation rdf:resource="http://www.opengis.net/def/docs/16-106r2"/>
+    <dct:dateSubmitted rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2016-05-16</dct:dateSubmitted>
+    <na:status rdf:resource="http://www.opengis.net/def/status/valid"/>
+    <skos:prefLabel>OGC® Land and Infrastructure Conceptual Model Standard (LandInfra)</skos:prefLabel>
+    <specrel:implementation rdf:resource="http://www.opengis.net/def/docs/16-105r2"/>
+    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/facility"/>
+    <specrel:implementation rdf:resource="http://www.opengis.net/def/docs/16-101r2"/>
+    <skos:notation rdf:datatype="http://www.opengis.net/def/metamodel/ogc-na/doc_no">15-111r1</skos:notation>
+    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment"/>
+    <adms:version>1.0</adms:version>
+    <dct:dateAccepted rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2016-08-02</dct:dateAccepted>
+    <prov:wasAttributedTo rdf:resource="http://www.opengis.net/def/wg/landinfraswg"/>
+    <spec:authority>Open Geospatial Consortium</spec:authority>
+    <specrel:implementation rdf:resource="http://www.opengis.net/def/docs/16-100r2"/>
+    <spec:class rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-core">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/alignment/description">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that, if the encoding supports linearly referenced locations, then the encoding provides the PositionExpression and related Classes specified in the OGC Abstract Specification Topic 19, core Linear Referencing (LR) Package shown in pink in Figure 7 that are appropriate to the supported subject area(s).</spec:purpose>
-    <skos:definition>Verify that, if the encoding supports linearly referenced locations, then the encoding provides the PositionExpression and related Classes specified in the OGC Abstract Specification Topic 19, core Linear Referencing (LR) Package shown in pink in Figure 7 that are appropriate to the supported subject area(s).</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-core"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-core</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:definition>An encoding which includes Alignments shall specify that all of the included Alignments shall be continuous, non-overlapping, and non-branching (though it may contain intersections with other Alignments) and that if it is used within the context of a Project, the included Alignment shall be for a single alternative, as specified by the ProjectPart.</skos:definition>
+    <skos:prefLabel>Requirement: /req/alignment/description</skos:prefLabel>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/subjects">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding specifies which of the LandInfra subjects it supports.</spec:purpose>
-    <skos:definition>Verify that the encoding specifies which of the LandInfra subjects it supports.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/subjects"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/subjects</skos:prefLabel>
     <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/classes">
     <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>The SurveyResults Requirements Class Classes shown in blue in Figure 52 shall
-be provided for by the encoding in a manner consistent with the encoding. An
-encoding shall decide which SurveyResult types it will support and define
-appropriate requirements classes accordingly.</dct:description>
-    <skos:definition>The SurveyResults Requirements Class Classes shown in blue in Figure 52 shall
-be provided for by the encoding in a manner consistent with the encoding. An
-encoding shall decide which SurveyResult types it will support and define
-appropriate requirements classes accordingly.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results"/>
-    <skos:prefLabel>Requirement: /req/survey-results/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <dct:description>An encoding which includes Alignments shall specify that all of the included Alignments shall be continuous, non-overlapping, and non-branching (though it may contain intersections with other Alignments) and that if it is used within the context of a Project, the included Alignment shall be for a single alternative, as specified by the ProjectPart.</dct:description>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section">
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/survey-results">
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/topic-20"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/classes"/>
+    <skos:definition>Requirement Class: SurveyResult</skos:definition>
+    <skos:prefLabel>Requirement Class: SurveyResult</skos:prefLabel>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/classes"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/topic-20"/>
     <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/measures">
+    <spec:purpose>If an encoding uses Alignment as a linear element, verify that it specifies that:
+1) If an Alignment2DHorizontal.2DLinestringRepresentation or an Alignment3D.3DLinestringRepresentation is specified as a linear element, then distanceAlong shall be measured along the LineString and offsetLateralDistance and offsetVerticalDistance values shall be measured normal to the LineString from this DistanceAlong point.
+2) If an Alignment2DHorizontal.segment list of Alignment2DHorSegments is used as a linear element, then distanceAlong and offsetLateralDistance values shall be measured in the horizontal plane, ignoring any vertical displacement of the Alignment.  OffsetVerticalDistance values shall be absolute from the horizontal plane unless an Alignment2DVertical is specified as a VerticalOffsetReferent so as to take into consideration vertical displacement of the Alignment, if present.</spec:purpose>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/measures</skos:prefLabel>
+    <skos:definition>If an encoding uses Alignment as a linear element, verify that it specifies that:
+1) If an Alignment2DHorizontal.2DLinestringRepresentation or an Alignment3D.3DLinestringRepresentation is specified as a linear element, then distanceAlong shall be measured along the LineString and offsetLateralDistance and offsetVerticalDistance values shall be measured normal to the LineString from this DistanceAlong point.
+2) If an Alignment2DHorizontal.segment list of Alignment2DHorSegments is used as a linear element, then distanceAlong and offsetLateralDistance values shall be measured in the horizontal plane, ignoring any vertical displacement of the Alignment.  OffsetVerticalDistance values shall be absolute from the horizontal plane unless an Alignment2DVertical is specified as a VerticalOffsetReferent so as to take into consideration vertical displacement of the Alignment, if present.</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/alignment"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/classes"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section"/>
-    <skos:definition>Requirement Class: RoadCrossSection</skos:definition>
-    <skos:prefLabel>Requirement Class: RoadCrossSection</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/classes"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/alignment"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/measures"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-1">
+    <skos:definition>Verify that the encoding provides the geometry types specified in the OGC Abstract Specification Topic 1, Feature Geometry as shown in pink and the SimpleTriangle, TIN, and PolyfaceMesh extensions shown in beige in Figure 6, that are appropriate to the supported subject area(s).
+  Verify that the encoding provides the additional geometry types not found in Topic 1, but required by a specific supported requirements class, are specified in that requirements class.</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-1"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-1</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <spec:purpose>Verify that the encoding provides the geometry types specified in the OGC Abstract Specification Topic 1, Feature Geometry as shown in pink and the SimpleTriangle, TIN, and PolyfaceMesh extensions shown in beige in Figure 6, that are appropriate to the supported subject area(s).
+  Verify that the encoding provides the additional geometry types not found in Topic 1, but required by a specific supported requirements class, are specified in that requirements class.</spec:purpose>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/railway/cant">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <skos:definition>Verify that the encoding specifies as a requirement that each CantSpecification shall cover the entire linear element the CantSpecification is located along from the linear element’s start to its end, and that the CantSpecification shall include CantEvents at the start and end of the linear element and wherever else there is a cant break along the linear element.</skos:definition>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway/cant"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/railway/cant</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:purpose>Verify that the encoding specifies as a requirement that each CantSpecification shall cover the entire linear element the CantSpecification is located along from the linear element’s start to its end, and that the CantSpecification shall include CantEvents at the start and end of the linear element and wherever else there is a cant break along the linear element.</spec:purpose>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-1">
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/subjects">
+    <skos:prefLabel>Requirement: /req/land-infra/subjects</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:definition>A Land and Infrastructure encoding shall specify which of the LandInfra subjects it supports: Facility, LandFeature, LandDivision, and Survey.</skos:definition>
+    <dct:description>A Land and Infrastructure encoding shall specify which of the LandInfra subjects it supports: Facility, LandFeature, LandDivision, and Survey.</dct:description>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
     <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>A Land and Infrastructure encoding shall support the geometry types specified in the OGC Abstract Specification Topic 1, Feature Geometry as shown in pink and the SimpleTriangle, TIN, and PolyfaceMesh extensions shown in beige in Figure 6, that are appropriate to the supported subject area(s). Additional geometry types, not found in Topic 1, but required by a specific requirements class, are specified in that requirements class. If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall support the PositionExpression and related Classes specified in the OGC Abstract Specification Topic 19, core Linear Referencing (LR) Package shown in pink in Figure 7 that are appropriate to the supported subject area(s). If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall specify which of the OGC Abstract Specification Topic 19, Linear Referencing extension packages it supports and shall therefore support the appropriate Classes shown in Figure 7 and Figure 8 for those packages that are appropriate to the supported subject area(s).</dct:description>
-    <skos:definition>A Land and Infrastructure encoding shall support the geometry types specified in the OGC Abstract Specification Topic 1, Feature Geometry as shown in pink and the SimpleTriangle, TIN, and PolyfaceMesh extensions shown in beige in Figure 6, that are appropriate to the supported subject area(s). Additional geometry types, not found in Topic 1, but required by a specific requirements class, are specified in that requirements class. If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall support the PositionExpression and related Classes specified in the OGC Abstract Specification Topic 19, core Linear Referencing (LR) Package shown in pink in Figure 7 that are appropriate to the supported subject area(s). If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall specify which of the OGC Abstract Specification Topic 19, Linear Referencing extension packages it supports and shall therefore support the appropriate Classes shown in Figure 7 and Figure 8 for those packages that are appropriate to the supported subject area(s).</skos:definition>
     <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
-    <skos:prefLabel>Requirement: /req/land-infra/topic-1</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/classes">
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/classes</skos:prefLabel>
+    <skos:definition>Verify that the encoding provides the SurveyResults Requirements Class Classes shown in blue in Figure 52 in a manner consistent with the encoding.  An encoding shall decide which SurveyResult types it will support and define appropriate requirements classes accordingly.</skos:definition>
+    <spec:purpose>Verify that the encoding provides the SurveyResults Requirements Class Classes shown in blue in Figure 52 in a manner consistent with the encoding.  An encoding shall decide which SurveyResult types it will support and define appropriate requirements classes accordingly.</spec:purpose>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results"/>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/classes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/def/status/submitted">
+    <dct:source rdf:resource="https://def.isotc211.org/iso19135/-1/2015/catalog-v001.xml"/>
+    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
+    <skos:definition xml:lang="en">A proposed entry which is not yet approved for use for use. Corresponds to ISO 19135:(redraft) 'submitted'.</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:broader rdf:resource="http://www.opengis.net/def/status/notAccepted"/>
+    <skos:prefLabel xml:lang="en">submitted</skos:prefLabel>
+    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusSubmitted"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/railway">
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:definition>The Railway Requirements Class supports those use cases where a designer wishes to exchange the output of the railway design with someone who is likely to use if for purposes other than further design. Consequently, the Railway Requirements Class covers design output such as 3D railway elements and track geometry including superelevation (cant).</skos:definition>
+    <skos:prefLabel>Conformance Class: Railway</skos:prefLabel>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway/classes"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway/alignment"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway/classes"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway/alignment"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway/cant"/>
+    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway/cant"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/crs">
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+    <dct:description>An encoding shall support coordinate reference systems in accordance with OGC Abstract Specification Topic 2, Spatial Referencing by Coordinates.</dct:description>
+    <skos:definition>An encoding shall support coordinate reference systems in accordance with OGC Abstract Specification Topic 2, Spatial Referencing by Coordinates.</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:prefLabel>Requirement: /req/land-infra/crs</skos:prefLabel>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/condominium/classes">
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:definition>The Condominium Requirements Class Classes shown in blue in Figure 68 shall be provided for by the encoding in a manner consistent with the encoding.</skos:definition>
+    <skos:prefLabel>Requirement: /req/condominium/classes</skos:prefLabel>
+    <dct:description>The Condominium Requirements Class Classes shown in blue in Figure 68 shall be provided for by the encoding in a manner consistent with the encoding.</dct:description>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/condominium"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/def/status/retired">
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <dct:source rdf:resource="https://def.isotc211.org/iso19135/-1/2015/catalog-v001.xml"/>
+    <skos:broader rdf:resource="http://www.opengis.net/def/status/deprecated"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:prefLabel xml:lang="en">retired</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:altlabel xml:lang="en">withdrawn</skos:altlabel>
+    <skos:definition xml:lang="en">An entry that has been withdrawn from use.  Corresponds to ISO 19135:2005 'retired'.</skos:definition>
+    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
+    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusRetired"/>
+    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/project">
+    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/project"/>
+    <skos:prefLabel>Conformance Class: Project</skos:prefLabel>
+    <spec:dependency rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/facility"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/project/classes"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/project/classes"/>
+    <skos:definition>A project is an activity related to the improvement of a facility, including design and/or construction.  This class may be for the creation, modification, or elimination of the entire facility or a part of the facility.  The Project Requirements Class includes information about projects and their decomposition into project parts.  In order to allow for the condition where none of the LandInfra dataset information is project related, this Requirements Class is optional.</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/project"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/classes">
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <spec:purpose>If an encoding includes Alignments, then verify that the encoding provides the Alignment Requirements Class Classes shown in blue in Figure 15 in a manner consistent with the encoding.</spec:purpose>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/classes</skos:prefLabel>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/classes"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:definition>If an encoding includes Alignments, then verify that the encoding provides the Alignment Requirements Class Classes shown in blue in Figure 15 in a manner consistent with the encoding.</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:definition>Features of the land, such as naturally occurring water features and vegetation are specified in the LandFeature Requirements Class as land features.  Also included are models of the land surface and subsurface layers.  Improvements to the land such as the construction of an embankment or the planting of landscape material are considered to be part of Site Facilities in the Facility Requirements Class.</skos:definition>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature"/>
+    <skos:prefLabel>Conformance Class: LandFeature</skos:prefLabel>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/classes"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/classes"/>
+    <spec:dependency rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/equipment/classes">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/equipment"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <skos:definition>Verify that the encoding provides the Equipment Requirements Class Classes shown in blue in Figure 48 in a manner consistent with the encoding.  An encoding shall decide which SurveySensor types it will support and define appropriate requirements classes accordingly.</skos:definition>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment/classes"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/equipment/classes</skos:prefLabel>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <spec:purpose>Verify that the encoding provides the Equipment Requirements Class Classes shown in blue in Figure 48 in a manner consistent with the encoding.  An encoding shall decide which SurveySensor types it will support and define appropriate requirements classes accordingly.</spec:purpose>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/railway">
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway/alignment"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:definition>Requirement Class: Railway</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway/cant"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway/alignment"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway/cant"/>
+    <skos:prefLabel>Requirement Class: Railway</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway/classes"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway/classes"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/facility">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/facility/classes"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes"/>
-    <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility"/>
-    <skos:definition>Conformance Class: Facility</skos:definition>
-    <skos:prefLabel>Conformance Class: Facility</skos:prefLabel>
     <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/facility/classes"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:definition>Facilities include collections of buildings and civil engineering works and their associated siteworks.  The Facilities Requirements Class includes the breakdown of facilities into discipline specific facility parts and introduces the notion of elements which make up these parts.  The Facilities Requirements Class only provides general support for facilities themselves, allowing subsequent Requirements Classes to focus on specific types of the parts that make up facilities, such as road and railway.  This Requirements Class is optional in order to allow for the condition where all of the LandInfra dataset information is not facility related, such as one containing only survey or land division information.</skos:definition>
+    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/facility/classes"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:prefLabel>Conformance Class: Facility</skos:prefLabel>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility"/>
+    <spec:dependency rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/alignment/classes">
     <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:prefLabel>Requirement: /req/alignment/classes</skos:prefLabel>
     <dct:description>The Alignment Requirements class Classes shown in blue in Figure 15 shall be
 provided for by any encoding which includes Alignments and then in such a
 manner as is consistent with the encoding.</dct:description>
     <skos:definition>An encoding shall implement the OGC Abstract Specification Topic 19 ILinearElement and ISpatial interfaces in a manner consistent with the encoding.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment"/>
-    <skos:prefLabel>Requirement: /req/alignment/classes</skos:prefLabel>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-division">
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-division/classes"/>
+    <skos:definition>Land can be divided up into land divisions.  These can either be public (political, judicial, or executive) or private in nature.  The former are administrative divisions and the latter are interests in land.  Both of these are specified in the LandDivision Requirements Class, though condominium interests in land are specified in a separate, Condominium Requirements Class.</skos:definition>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-division/classes"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-division"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:prefLabel>Conformance Class: LandDivision</skos:prefLabel>
+    <spec:dependency rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-division"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/CRS">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/equipment/observation-correction">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that an encoding requires that all geometry/locations for Alignment2DHorSegments and Alignment2DVertSegments be specified using the Alignment2DHorizontal.crs which shall be a Cartesian local engineering reference system.</spec:purpose>
-    <skos:definition>Verify that an encoding requires that all geometry/locations for Alignment2DHorSegments and Alignment2DVertSegments be specified using the Alignment2DHorizontal.crs which shall be a Cartesian local engineering reference system.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/CRS"/>
     <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/CRS</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/equipment"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <skos:definition>Verify that the encoding provides the ObservationCorrection Classes in blue in Figure 51 in a manner consistent with the encoding.  The encoding shall decide which correction types it will support and define appropriate requirements classes accordingly.</skos:definition>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment/observation-correction"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <spec:purpose>Verify that the encoding provides the ObservationCorrection Classes in blue in Figure 51 in a manner consistent with the encoding.  The encoding shall decide which correction types it will support and define appropriate requirements classes accordingly.</spec:purpose>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/equipment/observation-correction</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/survey/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/observations">
+    <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/observations"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/observations"/>
+    <skos:definition>Observations Requirements class is the package containing all information about the raw observations and the measurements observed during survey work. The raw observations are needed to enable later reprocessing or reporting of resulting properties of the observed feature of interest.</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/observations/classes"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>The Survey Requirements Class Classes shown in blue in Figure 41 shall be
-provided for by the encoding in a manner consistent with the encoding.</dct:description>
-    <skos:definition>The Survey Requirements Class Classes shown in blue in Figure 41 shall be
-provided for by the encoding in a manner consistent with the encoding.</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:prefLabel>Conformance Class: Observations</skos:prefLabel>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/observations/classes"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/def/status/accepted">
+    <skos:topConceptOf rdf:resource="http://www.opengis.net/def/status"/>
+    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/def/status/deprecated"/>
+    <dct:source rdf:resource="http://purl.org/linked-data/registry#"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/def/status/valid"/>
+    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusAccepted"/>
+    <skos:definition xml:lang="en">An entry that has been accepted for use and is visible in the default register listing. Includes entries that have seen been retired or superseded.</skos:definition>
+    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:prefLabel xml:lang="en">accepted</skos:prefLabel>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/road/classes">
+    <spec:purpose>Verify that the encoding provides the Road Requirements Class Classes shown in blue in Figure 21 in a manner consistent with the encoding.</spec:purpose>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:definition>Verify that the encoding provides the Road Requirements Class Classes shown in blue in Figure 21 in a manner consistent with the encoding.</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/road/classes</skos:prefLabel>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road/classes"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/topic-20">
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <dct:description>If a Land and Infrastructure encoding supports survey results subjects, then the encoding shall support the SF_SamplingFeature and related Classes specified in the OGC Abstract Specification Topic 20, Observation and Measurements shown in Figure 54 that are appropriate to the supported subject area(s).</dct:description>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:definition>If a Land and Infrastructure encoding supports survey results subjects, then the encoding shall support the SF_SamplingFeature and related Classes specified in the OGC Abstract Specification Topic 20, Observation and Measurements shown in Figure 54 that are appropriate to the supported subject area(s).</skos:definition>
     <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey"/>
-    <skos:prefLabel>Requirement: /req/survey/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+    <skos:prefLabel>Requirement: /req/survey-results/topic-20</skos:prefLabel>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/classes">
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19103">
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <skos:definition>Verify that the encoding provides the core data types specified in ISO 19103 Clause 7 and shown in pink in Figure 5 that are appropriate to the supported subject area(s).</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19103</skos:prefLabel>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19103"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <spec:purpose>Verify that the encoding provides the core data types specified in ISO 19103 Clause 7 and shown in pink in Figure 5 that are appropriate to the supported subject area(s).</spec:purpose>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/facility">
+    <skos:definition>Requirement Class: Facility</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility/classes"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/facility"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility/subtypes"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility/subtypes"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility/classes"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:prefLabel>Requirement Class: Facility</skos:prefLabel>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19109">
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <dct:description>Features shall be supported by a Land and Infrastructure encoding in accordance with the uml:feature requirement in ISO 19109:2015 Clause 8.2.6 and shown in Figure 9, as follows: Each instance of FeatureType shall be implemented by the encoding’s equivalent of a UML Class having a generalization association with AnyFeature and with a stereotype of &lt;&gt;.</dct:description>
+    <skos:prefLabel>Requirement: /req/land-infra/19109</skos:prefLabel>
+    <skos:definition>Features shall be supported by a Land and Infrastructure encoding in accordance with the uml:feature requirement in ISO 19109:2015 Clause 8.2.6 and shown in Figure 9, as follows: Each instance of FeatureType shall be implemented by the encoding’s equivalent of a UML Class having a generalization association with AnyFeature and with a stereotype of &lt;&gt;.</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
     <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>The LandInfra Requirements Class Classes shown in blue in Figure 2 shall be provided by the encoding in a manner consistent with the encoding.</dct:description>
-    <skos:definition>The LandInfra Requirements Class Classes shown in blue in Figure 2 shall be provided by the encoding in a manner consistent with the encoding.</skos:definition>
     <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
-    <skos:prefLabel>Requirement: /req/land-infra/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/subjects">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>A Land and Infrastructure encoding shall specify which of the LandInfra subjects it supports: Facility, LandFeature, LandDivision, and Survey.</dct:description>
-    <skos:definition>A Land and Infrastructure encoding shall specify which of the LandInfra subjects it supports: Facility, LandFeature, LandDivision, and Survey.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
-    <skos:prefLabel>Requirement: /req/land-infra/subjects</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-division/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>The LandDivision Requirements Class Classes shown in blue in Figure 60 shall be provided for by the encoding in a manner consistent with the encoding.</dct:description>
-    <skos:definition>The LandDivision Requirements Class Classes shown in blue in Figure 60 shall be provided for by the encoding in a manner consistent with the encoding.</skos:definition>
     <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-division"/>
-    <skos:prefLabel>Requirement: /req/land-division/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <dct:description>The LandDivision Requirements Class Classes shown in blue in Figure 60 shall be provided for by the encoding in a manner consistent with the encoding.</dct:description>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/def/status/retired">
-    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusRetired"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
-    <skos:definition xml:lang="en">An entry that has been withdrawn from use.  Corresponds to ISO 19135:2005 'retired'.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/def/status/deprecated"/>
-    <skos:altlabel xml:lang="en">withdrawn</skos:altlabel>
-    <skos:prefLabel xml:lang="en">retired</skos:prefLabel>
-    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
-    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
-    <dct:source rdf:resource="https://def.isotc211.org/iso19135/-1/2015/catalog-v001.xml"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:prefLabel>Requirement: /req/land-division/classes</skos:prefLabel>
+    <skos:definition>The LandDivision Requirements Class Classes shown in blue in Figure 60 shall be provided for by the encoding in a manner consistent with the encoding.</skos:definition>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/railway/classes">
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/crs">
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/crs"/>
+    <skos:definition>Verify that the encoding requirement for coordinate reference systems is consistent with OGC Abstract Specification Topic 2.</skos:definition>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/crs</skos:prefLabel>
+    <spec:purpose>Verify that the encoding requirement for coordinate reference systems is consistent with OGC Abstract Specification Topic 2.</spec:purpose>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/project">
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/project"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:definition>Requirement Class: Project</skos:definition>
+    <skos:prefLabel>Requirement Class: Project</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/project/classes"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/project/classes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/classes">
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature/classes"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <spec:purpose>Verify that the encoding provides the LandFeature Requirements Class Classes shown in blue in Figure 55 in a manner consistent with the encoding.</spec:purpose>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature"/>
+    <skos:prefLabel>ConformanceTest: http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/classes</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <skos:definition>Verify that the encoding provides the LandFeature Requirements Class Classes shown in blue in Figure 55 in a manner consistent with the encoding.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/classes">
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:definition>The LandInfra Requirements Class Classes shown in blue in Figure 2 shall be provided by the encoding in a manner consistent with the encoding.</skos:definition>
     <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>The Railway Requirements Class Classes shown in blue in Figure 36 shall be
-provided for by the encoding in a manner consistent with the encoding.</dct:description>
-    <skos:definition>The Railway Requirements Class Classes shown in blue in Figure 36 shall be
-provided for by the encoding in a manner consistent with the encoding.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway"/>
-    <skos:prefLabel>Requirement: /req/railway/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
+    <dct:description>The LandInfra Requirements Class Classes shown in blue in Figure 2 shall be provided by the encoding in a manner consistent with the encoding.</dct:description>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:prefLabel>Requirement: /req/land-infra/classes</skos:prefLabel>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/road">
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road/classes"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road/alignment"/>
+    <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road/alignment"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road"/>
+    <skos:definition>The Road Requirements Class supports those use cases in which a designer wishes to exchange the output of the design with someone who is likely to use it for purposes other than completing the road design.  Consequently, the Road Requirements Class includes several alternative ways for representing a design such as with 3D RoadElements, 3D StringLines (aka profile views, longitudinal breaklines, long sections), and 3D surfaces and layers, as well as collections of these.</skos:definition>
+    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:prefLabel>Conformance Class: Road</skos:prefLabel>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding provides the RoadCrossSection Requirements Class Classes shown in blue in Figure 25 in a manner consistent with the encoding.</spec:purpose>
-    <skos:definition>Verify that the encoding provides the RoadCrossSection Requirements Class Classes shown in blue in Figure 25 in a manner consistent with the encoding.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/classes"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/def/ont/modspec/Capabilities">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/TestType"/>
-    <skos:prefLabel>Capabilities</skos:prefLabel>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road/classes"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/alignment">
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:prefLabel>Requirement: /req/road-cross-section/alignment</skos:prefLabel>
+    <skos:definition>If an encoding allows the linear element used for locating CrossSections to be
+an Alignment, then that encoding shall support the Alignment Requirements
+Class.</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
     <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <dct:description>If an encoding allows the linear element used for locating CrossSections to be
 an Alignment, then that encoding shall support the Alignment Requirements
 Class.</dct:description>
-    <skos:definition>If an encoding allows the linear element used for locating CrossSections to be
-an Alignment, then that encoding shall support the Alignment Requirements
-Class.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section"/>
-    <skos:prefLabel>Requirement: /req/road-cross-section/alignment</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/def/status/experimental">
-    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
-    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/facility/subtypes">
+    <dct:description>A Land and Infrastructure encoding shall specify which of the FacilityPart subtypes shown in Figure 10 it supports.</dct:description>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility"/>
+    <skos:prefLabel>Requirement: /req/facility/subtypes</skos:prefLabel>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
-    <skos:prefLabel xml:lang="en">experimental</skos:prefLabel>
-    <skos:broader rdf:resource="http://www.opengis.net/def/status/valid"/>
-    <skos:altlabel xml:lang="en">provisional</skos:altlabel>
-    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusExperimental"/>
-    <skos:definition xml:lang="en">An entry that has been accepted into the register temporarily and may be subject to change or withdrawal.</skos:definition>
-    <dct:source rdf:resource="http://purl.org/linked-data/registry#"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/observations/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding provides the Observation Requirements Class Classes shown in blue in Figure 43 in a manner consistent with the encoding.  An encoding shall decide which SurveyObservation types it will support and define appropriate requirements classes accordingly. This then would include any dependent types (example SatelliteSystemType has only to be supported if the encoding will support GNSS Observations).</spec:purpose>
-    <skos:definition>Verify that the encoding provides the Observation Requirements Class Classes shown in blue in Figure 43 in a manner consistent with the encoding.  An encoding shall decide which SurveyObservation types it will support and define appropriate requirements classes accordingly. This then would include any dependent types (example SatelliteSystemType has only to be supported if the encoding will support GNSS Observations).</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/observations/classes"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/observations"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/observations/classes</skos:prefLabel>
+    <skos:definition>A Land and Infrastructure encoding shall specify which of the FacilityPart subtypes shown in Figure 10 it supports.</skos:definition>
     <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/def/status">
-    <dct:source rdf:resource="https://def.isotc211.org/iso19135/-1/2015/catalog-v001.xml"/>
-    <dct:source rdf:resource="http://purl.org/linked-data/registry#"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
-    <skos:prefLabel xml:lang="en">Register Item status values</skos:prefLabel>
-    <skos:hasTopConcept rdf:resource="http://www.opengis.net/def/status/accepted"/>
-    <skos:hasTopConcept rdf:resource="http://www.opengis.net/def/status/notAccepted"/>
-    <dct:provenance xml:lang="en">This vocabulary was originally pulbished by the OGC containing ISO 19135 terms. 19135 + additional terms were published by the British Government in 2012 as part of their work on Linked Data registry service. It was then adopted by the Australian Government Linked Data Working Group for Linked Data items in 2018. The extension of this vocabulary to include these additional terms, and term hierarchy, occured in July, 2020.
-  
-  The source of each Concept is indicated per-Concept as well as with a Collection for all ISO 19135 terms.</dct:provenance>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-07-05</dct:modified>
-    <dct:publisher rdf:resource="https://www.ogc.org"/>
-    <dct:creator rdf:resource="https://www.ogc.org"/>
-    <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-07-05</dct:created>
-    <na:collectionView rdf:resource="http://www.opengis.net/def/status/"/>
-    <skos:definition xml:lang="en">Statuses of items within a controlled register.
-  
-This vocabulary is a SKOS Concept Hierarchy of the RE_ItemStatus enumeration of ISO 19135: Geographic Information -- Procedures for item registration's Register with additional Concepts from the Core Ontology for Linked Data Registry Services.</skos:definition>
-    <dct:contributor rdf:resource="https://orcid.org/0000-0002-8742-7730"/>
-    <rdfs:seeAlso rdf:resource="http://www.opengis.net/ogc-na-policy#Status"/>
-    <na:status rdf:resource="http://www.opengis.net/def/status/experimental"/>
-    <spec:status rdf:resource="http://www.opengis.net/def/status/experimental"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/condominium">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/condominium/classes"/>
-    <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:definition>Conformance Class: Condominium</skos:definition>
-    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/condominium"/>
-    <skos:prefLabel>Conformance Class: Condominium</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/condominium"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/condominium/classes"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/equipment/observation-correction">
     <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-division">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>The ObservationCorrection Classes in blue in Figure 51 shall be provided for by the encoding in a manner consistent with the encoding. The encoding shall decide which correction types it will support and define appropriate requirements classes accordingly.</dct:description>
-    <skos:definition>The ObservationCorrection Classes in blue in Figure 51 shall be provided for by the encoding in a manner consistent with the encoding. The encoding shall decide which correction types it will support and define appropriate requirements classes accordingly.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment"/>
-    <skos:prefLabel>Requirement: /req/equipment/observation-correction</skos:prefLabel>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-division/classes"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-division"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-core">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall support the PositionExpression and related Classes specified in the OGC Abstract Specification Topic 19, core Linear Referencing (LR) Package shown in pink in Figure 7 that are appropriate to the supported subject area(s).</dct:description>
-    <skos:definition>If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall support the PositionExpression and related Classes specified in the OGC Abstract Specification Topic 19, core Linear Referencing (LR) Package shown in pink in Figure 7 that are appropriate to the supported subject area(s).</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
-    <skos:prefLabel>Requirement: /req/land-infra/topic-19-core</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:dependency rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding specifies which of the FacilityPart subtypes shown in Figure 10 it supports.</spec:purpose>
-    <skos:definition>Verify that the encoding specifies which of the FacilityPart subtypes shown in Figure 10 it supports.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility/subtypes"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes"/>
-    <skos:prefLabel>ConformanceTest: http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-1">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding provides the geometry types specified in the OGC Abstract Specification Topic 1, Feature Geometry as shown in pink and the SimpleTriangle, TIN, and PolyfaceMesh extensions shown in beige in Figure 6, that are appropriate to the supported subject area(s).
-  Verify that the encoding provides the additional geometry types not found in Topic 1, but required by a specific supported requirements class, are specified in that requirements class.</spec:purpose>
-    <skos:definition>Verify that the encoding provides the geometry types specified in the OGC Abstract Specification Topic 1, Feature Geometry as shown in pink and the SimpleTriangle, TIN, and PolyfaceMesh extensions shown in beige in Figure 6, that are appropriate to the supported subject area(s).
-  Verify that the encoding provides the additional geometry types not found in Topic 1, but required by a specific supported requirements class, are specified in that requirements class.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-1"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-1</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/def/status/accepted">
-    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
-    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:prefLabel xml:lang="en">accepted</skos:prefLabel>
-    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
-    <skos:topConceptOf rdf:resource="http://www.opengis.net/def/status"/>
-    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusAccepted"/>
-    <dct:source rdf:resource="http://purl.org/linked-data/registry#"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-    <skos:definition xml:lang="en">An entry that has been accepted for use and is visible in the default register listing. Includes entries that have seen been retired or superseded.</skos:definition>
-    <skos:narrower rdf:resource="http://www.opengis.net/def/status/deprecated"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/def/status/valid"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19103">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>A Land and Infrastructure encoding shall support the core data types specified in ISO 19103 Clause 7 and shown in pink in Figure 5 that are appropriate to the supported subject area(s).</dct:description>
-    <skos:definition>A Land and Infrastructure encoding shall support the core data types specified in ISO 19103 Clause 7 and shown in pink in Figure 5 that are appropriate to the supported subject area(s).</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
-    <skos:prefLabel>Requirement: /req/land-infra/19103</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/project">
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-division/classes"/>
     <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/project/classes"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/project"/>
-    <skos:definition>Requirement Class: Project</skos:definition>
-    <skos:prefLabel>Requirement Class: Project</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/project/classes"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/railway/cant">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding specifies as a requirement that each CantSpecification shall cover the entire linear element the CantSpecification is located along from the linear element’s start to its end, and that the CantSpecification shall include CantEvents at the start and end of the linear element and wherever else there is a cant break along the linear element.</spec:purpose>
-    <skos:definition>Verify that the encoding specifies as a requirement that each CantSpecification shall cover the entire linear element the CantSpecification is located along from the linear element’s start to its end, and that the CantSpecification shall include CantEvents at the start and end of the linear element and wherever else there is a cant break along the linear element.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway/cant"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/railway/cant</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/classes"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/alignment"/>
-    <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section"/>
-    <skos:definition>Conformance Class: RoadCrossSection</skos:definition>
-    <skos:prefLabel>Conformance Class: RoadCrossSection</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/alignment"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/classes"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/alignment">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/CRS"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/LR-interfaces"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/classes"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/description"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/measures"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment"/>
-    <skos:definition>Requirement Class: Alignment</skos:definition>
-    <skos:prefLabel>Requirement Class: Alignment</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/LR-interfaces"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/classes"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/measures"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/CRS"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/description"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:definition>Requirement Class: LandVision</skos:definition>
+    <skos:prefLabel>Requirement Class: LandVision</skos:prefLabel>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/alignment">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/classes"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/description"/>
     <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/CRS"/>
     <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/LR-interfaces"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/description"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:definition>An alignment is a positioning element which provides a Linear Referencing System for locating physical elements.  The Alignment Requirements Class specifies how an alignment is defined and used.</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
     <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/measures"/>
-    <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:definition>Conformance Class: Alignment</skos:definition>
-    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment"/>
     <skos:prefLabel>Conformance Class: Alignment</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/measures"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/CRS"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/LR-interfaces"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/description"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/classes"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/road/alignment">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that if the encoding allows the linear element used for locating RoadElements to be an Alignment, then that encoding supports the Alignment Requirements Class.</spec:purpose>
-    <skos:definition>Verify that if the encoding allows the linear element used for locating RoadElements to be an Alignment, then that encoding supports the Alignment Requirements Class.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road/alignment"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/road/alignment</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/facility">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility/classes"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility/subtypes"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/facility"/>
-    <skos:definition>Requirement Class: Facility</skos:definition>
-    <skos:prefLabel>Requirement Class: Facility</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility/classes"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility/subtypes"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/dataset">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding specifies a LandInfra dataset in a format appropriate for that encoding.</spec:purpose>
-    <skos:definition>Verify that the encoding specifies a LandInfra dataset in a format appropriate for that encoding.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/dataset"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/dataset</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/def/status/reserved">
-    <dct:source rdf:resource="http://purl.org/linked-data/registry#"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
-    <skos:definition xml:lang="en">A reserved entry allocated for some as yet undetermined future use.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/def/status/notAccepted"/>
-    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusReserved"/>
-    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
-    <skos:prefLabel xml:lang="en">reserved</skos:prefLabel>
-    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/observations">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/observations/classes"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/observations"/>
-    <skos:definition>Requirement Class: Observations</skos:definition>
-    <skos:prefLabel>Requirement Class: Observations</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/observations/classes"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/featureID">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>An encoding shall specify if it supports ID at the feature level, ID at the Feature sub-type level, or both.</dct:description>
-    <skos:definition>An encoding shall specify if it supports ID at the feature level, ID at the Feature sub-type level, or both.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
-    <skos:prefLabel>Requirement: /req/land-infra/featureID</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/project/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>The Project Requirements Class Classes shown in blue in Figure 13 shall be provided for by the encoding in a manner consistent with the encoding.</dct:description>
-    <skos:definition>The Project Requirements Class Classes shown in blue in Figure 13 shall be provided for by the encoding in a manner consistent with the encoding.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/project"/>
-    <skos:prefLabel>Requirement: /req/project/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/railway/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding provides the Railway Requirements Class Classes shown in blue in Figure 36 in a manner consistent with the encoding.</spec:purpose>
-    <skos:definition>Verify that the encoding provides the Railway Requirements Class Classes shown in blue in Figure 36 in a manner consistent with the encoding.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway/classes"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/railway/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/facility/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:dependency rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
-    <skos:definition>Verify that the encoding provides the Facility Requirements class Classes shown in blue in Figure 10 in a manner consistent with the encoding.</skos:definition>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding provides the Facility Requirements class Classes shown in blue in Figure 10 in a manner consistent with the encoding.</spec:purpose>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility/classes"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/facility"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/facility/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://purl.org/linked-data/registry#Register">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <skos:prefLabel>Governed Artefact</skos:prefLabel>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/def/status/invalid">
-    <skos:definition xml:lang="en">An entry which has been invalidated due to serious flaws, distinct from retirement. Corresponds to ISO 19135(redraft) 'invalid'.</skos:definition>
-    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
-    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
-    <dct:source rdf:resource="https://def.isotc211.org/iso19135/-1/2015/catalog-v001.xml"/>
-    <skos:prefLabel xml:lang="en">invalid</skos:prefLabel>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
-    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusInvalid"/>
-    <skos:broader rdf:resource="http://www.opengis.net/def/status/notAccepted"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19103">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding provides the core data types specified in ISO 19103 Clause 7 and shown in pink in Figure 5 that are appropriate to the supported subject area(s).</spec:purpose>
-    <skos:definition>Verify that the encoding provides the core data types specified in ISO 19103 Clause 7 and shown in pink in Figure 5 that are appropriate to the supported subject area(s).</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19103"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19103</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/dataset">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>A Land and Infrastructure encoding shall specify a LandInfra dataset in whatever format that is appropriate to that encoding (e.g., an XML document for a GML encoding).</dct:description>
-    <skos:definition>A Land and Infrastructure encoding shall specify a LandInfra dataset in whatever format that is appropriate to that encoding (e.g., an XML document for a GML encoding).</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
-    <skos:prefLabel>Requirement: /req/land-infra/dataset</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <spec:dependency rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/facility"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/classes"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <dct:description>The RoadCrossSection Requirements Class Classes shown in blue in Figure 25
 shall be provided for by the encoding in a manner consistent with the
 encoding.</dct:description>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:definition>The RoadCrossSection Requirements Class Classes shown in blue in Figure 25
 shall be provided for by the encoding in a manner consistent with the
 encoding.</skos:definition>
     <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road"/>
     <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section"/>
     <skos:prefLabel>Requirement: /req/road-cross-section/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/facility/classes">
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
     <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/survey">
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey/classes"/>
+    <skos:definition>The Survey Requirements Class is the main survey class and provides a framework for information about observations, processes and their results collected during survey work. The content of this package is similar to the OGC Sensor Model Language (SensorML). The main reason not to use the SensorML standard for this topic is to allow the observation and processes structured in a compact way similar to the LandXML format. Due to the high number of classes the Survey Package was split into different parts, Equipment, Observations and SurveyResults.</skos:definition>
+    <skos:prefLabel>Conformance Class: Survey</skos:prefLabel>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey/classes"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>The Facility Requirements Class Classes shown in blue in Figure 10 shall be provided for by the encoding in a manner consistent with the encoding.</dct:description>
-    <skos:definition>The Facility Requirements Class Classes shown in blue in Figure 10 shall be provided for by the encoding in a manner consistent with the encoding.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility"/>
-    <skos:prefLabel>Requirement: /req/facility/classes</skos:prefLabel>
+    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/def/status/submitted">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
-    <skos:definition xml:lang="en">A proposed entry which is not yet approved for use for use. Corresponds to ISO 19135:(redraft) 'submitted'.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/def/status/notAccepted"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
-    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
-    <dct:source rdf:resource="https://def.isotc211.org/iso19135/-1/2015/catalog-v001.xml"/>
-    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusSubmitted"/>
-    <skos:prefLabel xml:lang="en">submitted</skos:prefLabel>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/topic-20">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>If a Land and Infrastructure encoding supports survey results subjects, then the encoding shall support the SF_SamplingFeature and related Classes specified in the OGC Abstract Specification Topic 20, Observation and Measurements shown in Figure 54 that are appropriate to the supported subject area(s).</dct:description>
-    <skos:definition>If a Land and Infrastructure encoding supports survey results subjects, then the encoding shall support the SF_SamplingFeature and related Classes specified in the OGC Abstract Specification Topic 20, Observation and Measurements shown in Figure 54 that are appropriate to the supported subject area(s).</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results"/>
-    <skos:prefLabel>Requirement: /req/survey-results/topic-20</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature">
     <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
+    <spec:dependency rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/topic-20">
+    <spec:purpose>Verify that, if the encoding supports survey results subjects, then the encoding shall support the SF_SamplingFeature and related Classes specified in the OGC Abstract Specification Topic 20, Observation and Measurements shown in Figure 54 that are appropriate to the supported subject area(s).</spec:purpose>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/topic-20</skos:prefLabel>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/classes"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment"/>
-    <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature"/>
-    <skos:definition>Conformance Class: LandFeature</skos:definition>
-    <skos:prefLabel>Conformance Class: LandFeature</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/classes"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <skos:definition>Verify that, if the encoding supports survey results subjects, then the encoding shall support the SF_SamplingFeature and related Classes specified in the OGC Abstract Specification Topic 20, Observation and Measurements shown in Figure 54 that are appropriate to the supported subject area(s).</skos:definition>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/topic-20"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19103">
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+    <dct:description>A Land and Infrastructure encoding shall support the core data types specified in ISO 19103 Clause 7 and shown in pink in Figure 5 that are appropriate to the supported subject area(s).</dct:description>
+    <skos:prefLabel>Requirement: /req/land-infra/19103</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
+    <skos:definition>A Land and Infrastructure encoding shall support the core data types specified in ISO 19103 Clause 7 and shown in pink in Figure 5 that are appropriate to the supported subject area(s).</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/road/alignment">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:definition>If an encoding allows the linear element used for locating RoadElements to be
+an Alignment, then that encoding shall support the Alignment Requirements
+Class.</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:prefLabel>Requirement: /req/road/alignment</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <dct:description>If an encoding allows the linear element used for locating RoadElements to be
+an Alignment, then that encoding shall support the Alignment Requirements
+Class.</dct:description>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-core">
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-core"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-core</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <spec:purpose>Verify that, if the encoding supports linearly referenced locations, then the encoding provides the PositionExpression and related Classes specified in the OGC Abstract Specification Topic 19, core Linear Referencing (LR) Package shown in pink in Figure 7 that are appropriate to the supported subject area(s).</spec:purpose>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
+    <skos:definition>Verify that, if the encoding supports linearly referenced locations, then the encoding provides the PositionExpression and related Classes specified in the OGC Abstract Specification Topic 19, core Linear Referencing (LR) Package shown in pink in Figure 7 that are appropriate to the supported subject area(s).</skos:definition>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/def/status/valid">
-    <skos:broader rdf:resource="http://www.opengis.net/def/status/accepted"/>
-    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
-    <dct:source rdf:resource="https://def.isotc211.org/iso19135/-1/2015/catalog-v001.xml"/>
-    <skos:definition xml:lang="en">An entry that has been accepted into the register and is deemed fit for use. Corresponds to ISO 19135:2005 'valid'.</skos:definition>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  <rdf:Description rdf:about="http://www.opengis.net/def/status/reserved">
+    <skos:prefLabel xml:lang="en">reserved</skos:prefLabel>
+    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusReserved"/>
     <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
-    <skos:prefLabel xml:lang="en">valid</skos:prefLabel>
-    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusValid"/>
+    <skos:broader rdf:resource="http://www.opengis.net/def/status/notAccepted"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
     <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/def/status/stable"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/def/status/experimental"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/def/status/">
-    <skos:member rdf:resource="http://www.opengis.net/def/status/submitted"/>
-    <skos:member rdf:resource="http://www.opengis.net/def/status/experimental"/>
-    <skos:member rdf:resource="http://www.opengis.net/def/status/accepted"/>
-    <skos:member rdf:resource="http://www.opengis.net/def/status/invalid"/>
-    <skos:member rdf:resource="http://www.opengis.net/def/status/valid"/>
-    <skos:member rdf:resource="http://www.opengis.net/def/status/deprecated"/>
-    <skos:member rdf:resource="http://www.opengis.net/def/status/stable"/>
-    <skos:member rdf:resource="http://www.opengis.net/def/status/notAccepted"/>
-    <skos:member rdf:resource="http://www.opengis.net/def/status/retired"/>
-    <skos:member rdf:resource="http://www.opengis.net/def/status/superseded"/>
-    <skos:member rdf:resource="http://www.opengis.net/def/status/reserved"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Collection"/>
-    <skos:prefLabel xml:lang="en">Register Item status values</skos:prefLabel>
-    <skos:definition xml:lang="en">Register Item statuses from ISO19135 and subsequent Linked Data Registry extensions.</skos:definition>
-    <dct:provenance xml:lang="en">ISO19135 and subsequent Linked Data Registry extensions</dct:provenance>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/equipment/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding provides the Equipment Requirements Class Classes shown in blue in Figure 48 in a manner consistent with the encoding.  An encoding shall decide which SurveySensor types it will support and define appropriate requirements classes accordingly.</spec:purpose>
-    <skos:definition>Verify that the encoding provides the Equipment Requirements Class Classes shown in blue in Figure 48 in a manner consistent with the encoding.  An encoding shall decide which SurveySensor types it will support and define appropriate requirements classes accordingly.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment/classes"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/equipment"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/equipment/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:definition xml:lang="en">A reserved entry allocated for some as yet undetermined future use.</skos:definition>
+    <dct:source rdf:resource="http://purl.org/linked-data/registry#"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/observations">
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
+    <skos:prefLabel>Requirement Class: Observations</skos:prefLabel>
+    <skos:definition>Requirement Class: Observations</skos:definition>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/observations/classes"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/observations"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/observations/classes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://www.ogc.org">
+    <ns2:name>Open Geospatial Consortium</ns2:name>
+    <ns2:url rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://www.ogc.org</ns2:url>
+    <rdf:type rdf:resource="https://schema.org/Organization"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/def/status/invalid">
+    <skos:prefLabel xml:lang="en">invalid</skos:prefLabel>
+    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <dct:source rdf:resource="https://def.isotc211.org/iso19135/-1/2015/catalog-v001.xml"/>
+    <skos:definition xml:lang="en">An entry which has been invalidated due to serious flaws, distinct from retirement. Corresponds to ISO 19135(redraft) 'invalid'.</skos:definition>
+    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
+    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusInvalid"/>
+    <skos:broader rdf:resource="http://www.opengis.net/def/status/notAccepted"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-feature/classes">
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <dct:description>The LandFeature Requirements Class Classes shown in blue in Figure 55 shall be provided for by the encoding in a manner consistent with the encoding.</dct:description>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:prefLabel>Requirement: /req/land-feature/classes</skos:prefLabel>
+    <skos:definition>The LandFeature Requirements Class Classes shown in blue in Figure 55 shall be provided for by the encoding in a manner consistent with the encoding.</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/condominium/classes">
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/condominium"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/condominium/classes</skos:prefLabel>
+    <skos:definition>Verify that the encoding provides the Condominium Requirements Class Classes shown in blue in Figure 68 in a manner consistent with the encoding.</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/condominium/classes"/>
+    <spec:purpose>Verify that the encoding provides the Condominium Requirements Class Classes shown in blue in Figure 68 in a manner consistent with the encoding.</spec:purpose>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-extensions">
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-extensions</skos:prefLabel>
+    <skos:definition>Verify that, if the encoding supports linearly referenced locations, then the encoding specifies which of the OGC Abstract Specification Topic 19, Linear Referencing extension packages it supports and therefore supports the appropriate Classes shown in Figure 7 and Figure 8 for those packages that are appropriate to the supported subject area(s).</skos:definition>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-extensions"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <spec:purpose>Verify that, if the encoding supports linearly referenced locations, then the encoding specifies which of the OGC Abstract Specification Topic 19, Linear Referencing extension packages it supports and therefore supports the appropriate Classes shown in Figure 7 and Figure 8 for those packages that are appropriate to the supported subject area(s).</spec:purpose>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/observations/classes">
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/observations"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:definition>The Observations Requirements Class Classes shown in blue in Figure 41Figure
+43 shall be provided for by the encoding in a manner consistent with the
+encoding. An encoding shall decide which SurveyObservation types it will
+support and define appropriate requirements classes accordingly. This then
+would include any dependent types (example SatelliteSystemType has only to be
+supported if the encoding will support GNSS Observations).</skos:definition>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:prefLabel>Requirement: /req/observations/classes</skos:prefLabel>
+    <dct:description>The Observations Requirements Class Classes shown in blue in Figure 41Figure
+43 shall be provided for by the encoding in a manner consistent with the
+encoding. An encoding shall decide which SurveyObservation types it will
+support and define appropriate requirements classes accordingly. This then
+would include any dependent types (example SatelliteSystemType has only to be
+supported if the encoding will support GNSS Observations).</dct:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/def/status">
+    <skos:hasTopConcept rdf:resource="http://www.opengis.net/def/status/notAccepted"/>
+    <na:status rdf:resource="http://www.opengis.net/def/status/experimental"/>
+    <skos:hasTopConcept rdf:resource="http://www.opengis.net/def/status/accepted"/>
+    <dct:source rdf:resource="https://def.isotc211.org/iso19135/-1/2015/catalog-v001.xml"/>
+    <skos:definition xml:lang="en">Statuses of items within a controlled register.
+  
+This vocabulary is a SKOS Concept Hierarchy of the RE_ItemStatus enumeration of ISO 19135: Geographic Information -- Procedures for item registration's Register with additional Concepts from the Core Ontology for Linked Data Registry Services.</skos:definition>
+    <rdfs:seeAlso rdf:resource="http://www.opengis.net/ogc-na-policy#Status"/>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-07-05</dct:modified>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+    <spec:status rdf:resource="http://www.opengis.net/def/status/experimental"/>
+    <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-07-05</dct:created>
+    <skos:prefLabel xml:lang="en">Register Item status values</skos:prefLabel>
+    <dct:contributor rdf:resource="https://orcid.org/0000-0002-8742-7730"/>
+    <dct:provenance xml:lang="en">This vocabulary was originally pulbished by the OGC containing ISO 19135 terms. 19135 + additional terms were published by the British Government in 2012 as part of their work on Linked Data registry service. It was then adopted by the Australian Government Linked Data Working Group for Linked Data items in 2018. The extension of this vocabulary to include these additional terms, and term hierarchy, occured in July, 2020.
+  
+  The source of each Concept is indicated per-Concept as well as with a Collection for all ISO 19135 terms.</dct:provenance>
+    <dct:source rdf:resource="http://purl.org/linked-data/registry#"/>
+    <dct:publisher rdf:resource="https://www.ogc.org"/>
+    <dct:creator rdf:resource="https://www.ogc.org"/>
+    <na:collectionView rdf:resource="http://www.opengis.net/def/status/"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19109">
+    <skos:definition>Verify that Features shall be supported by a Land and Infrastructure encoding in accordance with the uml:feature requirement in ISO 19109:2015 Clause 8.2.6 and shown in Figure 9, as follows:   Each instance of FeatureType shall be implemented by the encoding’s equivalent of a UML Class having a generalization association with AnyFeature and with a stereotype of &lt;&lt;FeatureType&gt;&gt;.</skos:definition>
+    <spec:purpose>Verify that Features shall be supported by a Land and Infrastructure encoding in accordance with the uml:feature requirement in ISO 19109:2015 Clause 8.2.6 and shown in Figure 9, as follows:   Each instance of FeatureType shall be implemented by the encoding’s equivalent of a UML Class having a generalization association with AnyFeature and with a stereotype of &lt;&lt;FeatureType&gt;&gt;.</spec:purpose>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19109"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19109</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-core">
+    <skos:definition>If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall support the PositionExpression and related Classes specified in the OGC Abstract Specification Topic 19, core Linear Referencing (LR) Package shown in pink in Figure 7 that are appropriate to the supported subject area(s).</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
+    <skos:prefLabel>Requirement: /req/land-infra/topic-19-core</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <dct:description>If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall support the PositionExpression and related Classes specified in the OGC Abstract Specification Topic 19, core Linear Referencing (LR) Package shown in pink in Figure 7 that are appropriate to the supported subject area(s).</dct:description>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section">
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/classes"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
+    <skos:definition>Requirement Class: RoadCrossSection</skos:definition>
+    <skos:prefLabel>Requirement Class: RoadCrossSection</skos:prefLabel>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/classes"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/alignment"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/alignment"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that theencoding provides the LandInfra Requirements Class Classes shown in blue in Figure 2 in a manner consistent with the encoding.</spec:purpose>
     <skos:definition>Verify that theencoding provides the LandInfra Requirements Class Classes shown in blue in Figure 2 in a manner consistent with the encoding.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/classes"/>
     <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
     <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
     <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/classes</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/classes"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <spec:purpose>Verify that theencoding provides the LandInfra Requirements Class Classes shown in blue in Figure 2 in a manner consistent with the encoding.</spec:purpose>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/def/status/under-development">
-    <skos:broader rdf:resource="http://www.opengis.net/def/status/notAccepted"/>
-    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/LR-interfaces">
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/LR-interfaces</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/LR-interfaces"/>
+    <spec:purpose>Verify that the encoding implements the OGC Abstract Specification Topic 19 ILinearElement and ISpatial interfaces in a manner consistent with the encoding.</spec:purpose>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:definition>Verify that the encoding implements the OGC Abstract Specification Topic 19 ILinearElement and ISpatial interfaces in a manner consistent with the encoding.</skos:definition>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/condominium">
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/condominium"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/condominium/classes"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/condominium/classes"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:prefLabel>Conformance Class: Condominium</skos:prefLabel>
+    <spec:dependency rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-division"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
+    <skos:definition>A condominium denotes concurrent ownership of real property that has been divided into private and common portions.  The Condominium Requirements Class includes information about condominium units, buildings and schemes.</skos:definition>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/condominium"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/def/status/valid">
+    <skos:narrower rdf:resource="http://www.opengis.net/def/status/stable"/>
+    <skos:definition xml:lang="en">An entry that has been accepted into the register and is deemed fit for use. Corresponds to ISO 19135:2005 'valid'.</skos:definition>
+    <skos:broader rdf:resource="http://www.opengis.net/def/status/accepted"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <dct:source rdf:resource="https://def.isotc211.org/iso19135/-1/2015/catalog-v001.xml"/>
+    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusValid"/>
     <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-    <na:status rdf:resource="http://www.opengis.net/def/status/experimental"/>
-    <skos:definition xml:lang="en">An entry that is under development, but is part of a committed roadmap, rather than experimental</skos:definition>
-    <skos:prefLabel xml:lang="en">Under Development</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">valid</skos:prefLabel>
+    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/def/status/experimental"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-division">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-division/classes"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-division"/>
-    <skos:definition>Requirement Class: LandVision</skos:definition>
-    <skos:prefLabel>Requirement Class: LandVision</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-division/classes"/>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/alignment/CRS">
+    <skos:prefLabel>Requirement: /req/alignment/CRS</skos:prefLabel>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <dct:description>All geometry/locations for Alignment2DHorSegments and Alignment2DVertSegments shall be specified using the Alignment2DHorizontal.crs which shall be a Cartesian local engineering reference system.</dct:description>
     <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/observations">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/observations/classes"/>
-    <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/observations"/>
-    <skos:definition>Conformance Class: Observations</skos:definition>
-    <skos:prefLabel>Conformance Class: Observations</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/observations/classes"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/observations"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/project">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/project/classes"/>
-    <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/project"/>
-    <skos:definition>Conformance Class: Project</skos:definition>
-    <skos:prefLabel>Conformance Class: Project</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/project"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/project/classes"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/railway">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway/classes"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway/alignment"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway/cant"/>
-    <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway"/>
-    <skos:definition>Conformance Class: Railway</skos:definition>
-    <skos:prefLabel>Conformance Class: Railway</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway/classes"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway/cant"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway/alignment"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/road/classes">
     <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>The Road Requirements Class Classes shown in blue in Figure 21 shall be
-provided for by the encoding in a manner consistent with the encoding.</dct:description>
-    <skos:definition>The Road Requirements Class Classes shown in blue in Figure 21 shall be
-provided for by the encoding in a manner consistent with the encoding.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road"/>
-    <skos:prefLabel>Requirement: /req/road/classes</skos:prefLabel>
+    <skos:definition>All geometry/locations for Alignment2DHorSegments and Alignment2DVertSegments shall be specified using the Alignment2DHorizontal.crs which shall be a Cartesian local engineering reference system.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/dataset">
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/dataset"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
+    <skos:definition>Verify that the encoding specifies a LandInfra dataset in a format appropriate for that encoding.</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/dataset</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:purpose>Verify that the encoding specifies a LandInfra dataset in a format appropriate for that encoding.</spec:purpose>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/project/classes">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <dct:description>The Project Requirements Class Classes shown in blue in Figure 13 shall be provided for by the encoding in a manner consistent with the encoding.</dct:description>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/project"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:prefLabel>Requirement: /req/project/classes</skos:prefLabel>
+    <skos:definition>The Project Requirements Class Classes shown in blue in Figure 13 shall be provided for by the encoding in a manner consistent with the encoding.</skos:definition>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/railway/classes">
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/railway/classes</skos:prefLabel>
+    <skos:definition>Verify that the encoding provides the Railway Requirements Class Classes shown in blue in Figure 36 in a manner consistent with the encoding.</skos:definition>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <spec:purpose>Verify that the encoding provides the Railway Requirements Class Classes shown in blue in Figure 36 in a manner consistent with the encoding.</spec:purpose>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway/classes"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/def/status/deprecated">
+    <skos:prefLabel xml:lang="en">deprecated</skos:prefLabel>
+    <dct:source rdf:resource="http://purl.org/linked-data/registry#"/>
+    <skos:broader rdf:resource="http://www.opengis.net/def/status/accepted"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:definition xml:lang="en">An entry that has been retired or replaced and is no longer to be used.</skos:definition>
+    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusDeprecated"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/def/status/superseded"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/def/status/retired"/>
+    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/crs">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/classes">
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding requirement for coordinate reference systems is consistent with OGC Abstract Specification Topic 2.</spec:purpose>
-    <skos:definition>Verify that the encoding requirement for coordinate reference systems is consistent with OGC Abstract Specification Topic 2.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/crs"/>
+    <skos:definition>The SurveyResults Requirements Class Classes shown in blue in Figure 52 shall
+be provided for by the encoding in a manner consistent with the encoding. An
+encoding shall decide which SurveyResult types it will support and define
+appropriate requirements classes accordingly.</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <dct:description>The SurveyResults Requirements Class Classes shown in blue in Figure 52 shall
+be provided for by the encoding in a manner consistent with the encoding. An
+encoding shall decide which SurveyResult types it will support and define
+appropriate requirements classes accordingly.</dct:description>
+    <skos:prefLabel>Requirement: /req/survey-results/classes</skos:prefLabel>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/alignment/CRS">
     <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/crs</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:purpose>Verify that an encoding requires that all geometry/locations for Alignment2DHorSegments and Alignment2DVertSegments be specified using the Alignment2DHorizontal.crs which shall be a Cartesian local engineering reference system.</spec:purpose>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/CRS"/>
+    <skos:definition>Verify that an encoding requires that all geometry/locations for Alignment2DHorSegments and Alignment2DVertSegments be specified using the Alignment2DHorizontal.crs which shall be a Cartesian local engineering reference system.</skos:definition>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/CRS</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0">
+    <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2016-12-20</dct:created>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2016-12-20</dct:modified>
+    <na:status rdf:resource="http://www.opengis.net/def/status/experimental"/>
+    <skos:prefLabel>Specification elements for OGC 15-111r LandInfra</skos:prefLabel>
+    <skos:hasTopConcept rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
+    <skos:definition>A convenience hierarchy for navigating the elements of a specification using the SKOS model</skos:definition>
+    <dct:source rdf:resource="http://www.opengis.net/def/docs/15-111r1"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+    <spec:status rdf:resource="http://www.opengis.net/def/status/experimental"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/alignment">
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/CRS"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/LR-interfaces"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/classes"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/measures"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/description"/>
+    <skos:prefLabel>Requirement Class: Alignment</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/LR-interfaces"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/CRS"/>
+    <skos:definition>Requirement Class: Alignment</skos:definition>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/description"/>
+    <skos:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/alignment"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/classes"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment/measures"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-extensions">
+    <skos:definition>If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall specify which of the OGC Abstract Specification Topic 19, Linear Referencing extension packages it supports and shall therefore support the appropriate Classes shown in Figure 7 and Figure 8 for those packages that are appropriate to the supported subject area(s).</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <dct:description>If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall specify which of the OGC Abstract Specification Topic 19, Linear Referencing extension packages it supports and shall therefore support the appropriate Classes shown in Figure 7 and Figure 8 for those packages that are appropriate to the supported subject area(s).</dct:description>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:prefLabel>Requirement: /req/land-infra/topic-19-extensions</skos:prefLabel>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/alignment/measures">
+    <dct:description>If an Alignment2DHorizontal.2DLinestringRepresentation or an Alignment3D.3DLinestringRepresentation is specified as a linear element, then distanceAlong shall be measured along the LineString and offsetLateralDistance and offsetVerticalDistance values shall be measured normal to the LineString from this DistanceAlong point. If an Alignment2DHorizontal.segment list of Alignment2DHorSegments is used as a linear element, then distanceAlong and offsetLateralDistance values shall be measured in the horizontal plane, ignoring any vertical displacement of the Alignment. OffsetVerticalDistance values shall be absolute from the horizontal plane unless an Alignment2DVertical is specified as a VerticalOffsetReferent so as to take into consideration vertical displacement of the Alignment, if present.</dct:description>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment"/>
+    <skos:prefLabel>Requirement: /req/alignment/measures</skos:prefLabel>
+    <skos:definition>If an Alignment2DHorizontal.2DLinestringRepresentation or an Alignment3D.3DLinestringRepresentation is specified as a linear element, then distanceAlong shall be measured along the LineString and offsetLateralDistance and offsetVerticalDistance values shall be measured normal to the LineString from this DistanceAlong point. If an Alignment2DHorizontal.segment list of Alignment2DHorSegments is used as a linear element, then distanceAlong and offsetLateralDistance values shall be measured in the horizontal plane, ignoring any vertical displacement of the Alignment. OffsetVerticalDistance values shall be absolute from the horizontal plane unless an Alignment2DVertical is specified as a VerticalOffsetReferent so as to take into consideration vertical displacement of the Alignment, if present.</skos:definition>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/featureID">
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/featureID</skos:prefLabel>
+    <skos:definition>Verify that the encoding specifies whether it supports ID at the feature level, ID at the Feature sub-type level, or both.</skos:definition>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/featureID"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <spec:purpose>Verify that the encoding specifies whether it supports ID at the feature level, ID at the Feature sub-type level, or both.</spec:purpose>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-infra"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/survey">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/classes"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/topic-20"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey/classes"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/classes"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey"/>
+    <skos:definition>Requirement Class: Survey</skos:definition>
+    <skos:prefLabel>Requirement Class: Survey</skos:prefLabel>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results/topic-20"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey/classes"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/hasPart">
+    <skos:prefLabel>Has Part</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/railway/alignment">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
     <spec:purpose>Verify that if the encoding allows the linear element used for locating RailwayElements or CantEvents to be an Alignment, then that encoding supports the Alignment Requirements Class.</spec:purpose>
-    <skos:definition>Verify that if the encoding allows the linear element used for locating RailwayElements or CantEvents to be an Alignment, then that encoding supports the Alignment Requirements Class.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway/alignment"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/railway/alignment</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/def/ont/modspec/CM">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/StandardizationTargetType"/>
-    <skos:prefLabel>Conceptual Model</skos:prefLabel>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-division">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-division/classes"/>
-    <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-division"/>
-    <skos:definition>Conformance Class: LandDivision</skos:definition>
-    <skos:prefLabel>Conformance Class: LandDivision</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-division/classes"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-division"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/equipment/observation-correction">
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
     <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
-    <spec:purpose>Verify that the encoding provides the ObservationCorrection Classes in blue in Figure 51 in a manner consistent with the encoding.  The encoding shall decide which correction types it will support and define appropriate requirements classes accordingly.</spec:purpose>
-    <skos:definition>Verify that the encoding provides the ObservationCorrection Classes in blue in Figure 51 in a manner consistent with the encoding.  The encoding shall decide which correction types it will support and define appropriate requirements classes accordingly.</skos:definition>
-    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment/observation-correction"/>
-    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/equipment"/>
-    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/equipment/observation-correction</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/railway/alignment</skos:prefLabel>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/railway"/>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway/alignment"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:definition>Verify that if the encoding allows the linear element used for locating RailwayElements or CantEvents to be an Alignment, then that encoding supports the Alignment Requirements Class.</skos:definition>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Collection"/>
-    <dct:source rdf:resource="http://www.opengis.net/def/docs/15-111r1"/>
     <skos:definition>LandInfra conceptual model collection of Conformance Classes</skos:definition>
+    <dct:source rdf:resource="http://www.opengis.net/def/docs/15-111r1"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/survey/classes">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <dct:description>The Survey Requirements Class Classes shown in blue in Figure 41 shall be
+provided for by the encoding in a manner consistent with the encoding.</dct:description>
+    <skos:prefLabel>Requirement: /req/survey/classes</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:definition>The Survey Requirements Class Classes shown in blue in Figure 41 shall be
+provided for by the encoding in a manner consistent with the encoding.</skos:definition>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/equipment">
+    <skos:definition>Requirement Class: Equipment</skos:definition>
+    <skos:prefLabel>Requirement Class: Equipment</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment/classes"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment/observation-correction"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment/classes"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment/observation-correction"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/equipment"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/def/status/iso19135">
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:member rdf:resource="http://www.opengis.net/def/status/valid"/>
+    <skos:definition xml:lang="en">Register Item status values according to ISO19135.</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <dct:source rdf:resource="https://def.isotc211.org/iso19135/-1/2015/CoreModel.rdf"/>
+    <skos:member rdf:resource="http://www.opengis.net/def/status/superseded"/>
+    <skos:member rdf:resource="http://www.opengis.net/def/status/submitted"/>
+    <skos:member rdf:resource="http://www.opengis.net/def/status/invalid"/>
+    <skos:member rdf:resource="http://www.opengis.net/def/status/retired"/>
+    <skos:prefLabel xml:lang="en">ISO 19135 Register Item status values</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Collection"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-feature">
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-feature"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature/alignment"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature/classes"/>
+    <skos:prefLabel>Requirement Class: LandFeature</skos:prefLabel>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature/classes"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature/alignment"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:definition>Requirement Class: LandFeature</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/equipment/observation-correction">
+    <skos:prefLabel>Requirement: /req/equipment/observation-correction</skos:prefLabel>
+    <skos:definition>The ObservationCorrection Classes in blue in Figure 51 shall be provided for by the encoding in a manner consistent with the encoding. The encoding shall decide which correction types it will support and define appropriate requirements classes accordingly.</skos:definition>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <dct:description>The ObservationCorrection Classes in blue in Figure 51 shall be provided for by the encoding in a manner consistent with the encoding. The encoding shall decide which correction types it will support and define appropriate requirements classes accordingly.</dct:description>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/dataset">
+    <dct:description>A Land and Infrastructure encoding shall specify a LandInfra dataset in whatever format that is appropriate to that encoding (e.g., an XML document for a GML encoding).</dct:description>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
+    <skos:prefLabel>Requirement: /req/land-infra/dataset</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:definition>A Land and Infrastructure encoding shall specify a LandInfra dataset in whatever format that is appropriate to that encoding (e.g., an XML document for a GML encoding).</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/railway/classes">
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:definition>The Railway Requirements Class Classes shown in blue in Figure 36 shall be
+provided for by the encoding in a manner consistent with the encoding.</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <dct:description>The Railway Requirements Class Classes shown in blue in Figure 36 shall be
+provided for by the encoding in a manner consistent with the encoding.</dct:description>
+    <skos:prefLabel>Requirement: /req/railway/classes</skos:prefLabel>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/classes">
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/classes</skos:prefLabel>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section"/>
+    <skos:definition>Verify that the encoding provides the RoadCrossSection Requirements Class Classes shown in blue in Figure 25 in a manner consistent with the encoding.</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/classes"/>
+    <spec:purpose>Verify that the encoding provides the RoadCrossSection Requirements Class Classes shown in blue in Figure 25 in a manner consistent with the encoding.</spec:purpose>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/project/classes">
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/project"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <spec:purpose>Verify that the encoding provides the Project Requirements Class Classes shown in blue in Figure 13 in a manner consistent with the encoding.</spec:purpose>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/project/classes"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/project/classes</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:definition>Verify that the encoding provides the Project Requirements Class Classes shown in blue in Figure 13 in a manner consistent with the encoding.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-1">
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:definition>A Land and Infrastructure encoding shall support the geometry types specified in the OGC Abstract Specification Topic 1, Feature Geometry as shown in pink and the SimpleTriangle, TIN, and PolyfaceMesh extensions shown in beige in Figure 6, that are appropriate to the supported subject area(s). Additional geometry types, not found in Topic 1, but required by a specific requirements class, are specified in that requirements class. If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall support the PositionExpression and related Classes specified in the OGC Abstract Specification Topic 19, core Linear Referencing (LR) Package shown in pink in Figure 7 that are appropriate to the supported subject area(s). If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall specify which of the OGC Abstract Specification Topic 19, Linear Referencing extension packages it supports and shall therefore support the appropriate Classes shown in Figure 7 and Figure 8 for those packages that are appropriate to the supported subject area(s).</skos:definition>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+    <dct:description>A Land and Infrastructure encoding shall support the geometry types specified in the OGC Abstract Specification Topic 1, Feature Geometry as shown in pink and the SimpleTriangle, TIN, and PolyfaceMesh extensions shown in beige in Figure 6, that are appropriate to the supported subject area(s). Additional geometry types, not found in Topic 1, but required by a specific requirements class, are specified in that requirements class. If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall support the PositionExpression and related Classes specified in the OGC Abstract Specification Topic 19, core Linear Referencing (LR) Package shown in pink in Figure 7 that are appropriate to the supported subject area(s). If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall specify which of the OGC Abstract Specification Topic 19, Linear Referencing extension packages it supports and shall therefore support the appropriate Classes shown in Figure 7 and Figure 8 for those packages that are appropriate to the supported subject area(s).</dct:description>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:prefLabel>Requirement: /req/land-infra/topic-1</skos:prefLabel>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/alignment/measures">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/alignment/LR-interfaces">
+    <dct:description>An encoding shall implement the OGC Abstract Specification Topic 19 ILinearElement and ISpatial interfaces in a manner consistent with the encoding.</dct:description>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>If an Alignment2DHorizontal.2DLinestringRepresentation or an Alignment3D.3DLinestringRepresentation is specified as a linear element, then distanceAlong shall be measured along the LineString and offsetLateralDistance and offsetVerticalDistance values shall be measured normal to the LineString from this DistanceAlong point. If an Alignment2DHorizontal.segment list of Alignment2DHorSegments is used as a linear element, then distanceAlong and offsetLateralDistance values shall be measured in the horizontal plane, ignoring any vertical displacement of the Alignment. OffsetVerticalDistance values shall be absolute from the horizontal plane unless an Alignment2DVertical is specified as a VerticalOffsetReferent so as to take into consideration vertical displacement of the Alignment, if present.</dct:description>
-    <skos:definition>If an Alignment2DHorizontal.2DLinestringRepresentation or an Alignment3D.3DLinestringRepresentation is specified as a linear element, then distanceAlong shall be measured along the LineString and offsetLateralDistance and offsetVerticalDistance values shall be measured normal to the LineString from this DistanceAlong point. If an Alignment2DHorizontal.segment list of Alignment2DHorSegments is used as a linear element, then distanceAlong and offsetLateralDistance values shall be measured in the horizontal plane, ignoring any vertical displacement of the Alignment. OffsetVerticalDistance values shall be absolute from the horizontal plane unless an Alignment2DVertical is specified as a VerticalOffsetReferent so as to take into consideration vertical displacement of the Alignment, if present.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment"/>
-    <skos:prefLabel>Requirement: /req/alignment/measures</skos:prefLabel>
     <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/alignment"/>
+    <skos:prefLabel>Requirement: /req/alignment/LR-interfaces</skos:prefLabel>
+    <skos:definition>An encoding shall implement the OGC Abstract Specification Topic 19 ILinearElement and ISpatial interfaces in a manner consistent with the encoding.</skos:definition>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/equipment/classes">
+    <skos:prefLabel>Requirement: /req/equipment/classes</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <dct:description>The Equipment Requirements Class Classes shown in blue in Figure 48 shall be provided for by the encoding in a manner consistent with the encoding. An encoding shall decide which SurveySensor types it will support and define appropriate requirements classes accordingly.</dct:description>
+    <skos:definition>The Equipment Requirements Class Classes shown in blue in Figure 48 shall be provided for by the encoding in a manner consistent with the encoding. An encoding shall decide which SurveySensor types it will support and define appropriate requirements classes accordingly.</skos:definition>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/railway/cant">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:prefLabel>Requirement: /req/railway/cant</skos:prefLabel>
+    <skos:definition>An encoding shall specify as a requirement that each CantSpecification shall
+cover the entire linear element the CantSpecification is located along from
+the linear element’s start to its end, and that the CantSpecification shall
+include CantEvents at the start and end of the linear element and wherever
+else there is a cant break along the linear element.</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <dct:description>An encoding shall specify as a requirement that each CantSpecification shall
+cover the entire linear element the CantSpecification is located along from
+the linear element’s start to its end, and that the CantSpecification shall
+include CantEvents at the start and end of the linear element and wherever
+else there is a cant break along the linear element.</dct:description>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.opengis.net/def/status/stable">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
-    <dct:source rdf:resource="http://purl.org/linked-data/registry#"/>
-    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
-    <skos:prefLabel xml:lang="en">stable</skos:prefLabel>
-    <skos:definition xml:lang="en">An entry that is seen as having a reasonable measure of stability, may be used to mark the full adoption of a previously 'experimental' entry.</skos:definition>
     <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusStable"/>
+    <dct:source rdf:resource="http://purl.org/linked-data/registry#"/>
     <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
+    <skos:definition xml:lang="en">An entry that is seen as having a reasonable measure of stability, may be used to mark the full adoption of a previously 'experimental' entry.</skos:definition>
     <skos:broader rdf:resource="http://www.opengis.net/def/status/valid"/>
+    <skos:prefLabel xml:lang="en">stable</skos:prefLabel>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/def/ont/modspec/Basic">
-    <skos:prefLabel>Basic</skos:prefLabel>
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/TestType"/>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/equipment">
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/equipment/classes"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/equipment/classes"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:prefLabel>Conformance Class: Equipment</skos:prefLabel>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment"/>
+    <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/equipment/observation-correction"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
+    <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/equipment"/>
+    <skos:definition>In the Equipment Requirements class all information about the processes and the sensors is available that had been used for the determination of an observation.</skos:definition>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/equipment/observation-correction"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:definition>The SurveyResults Requirements Class contains the observed property of a feature of interest.  Using sampling features from the Observation &amp; Measurements (O&amp;M) standard, the dependencies between the observation acts and the results are realized.</skos:definition>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:prefLabel>Conformance Class: Survey Results</skos:prefLabel>
     <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/classes"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/classes"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/topic-20"/>
     <spec:conformanceTest rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/topic-20"/>
     <skos:topConceptOf rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:requirementsTested rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results"/>
-    <skos:definition>Conformance Class: SurveyResults</skos:definition>
-    <skos:prefLabel>Conformance Class: SurveyResults</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/survey-results"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/classes"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/topic-20"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceClass"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/road">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/alignment"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/classes"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road/alignment"/>
-    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road/classes"/>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/road"/>
-    <skos:definition>Requirement Class: Road</skos:definition>
-    <skos:prefLabel>Requirement Class: Road</skos:prefLabel>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/classes"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/alignment"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road/alignment"/>
-    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road/classes"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes">
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility/subtypes"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <skos:prefLabel>ConformanceTest: http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes</skos:prefLabel>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <spec:purpose>Verify that the encoding specifies which of the FacilityPart subtypes shown in Figure 10 it supports.</spec:purpose>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/railway/alignment">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>If an encoding allows the linear element used for locating RailwayElements or
-CantEvents to be an Alignment, then that encoding shall support the Alignment
-Requirements Class.</dct:description>
-    <skos:definition>If an encoding allows the linear element used for locating RailwayElements or
-CantEvents to be an Alignment, then that encoding shall support the Alignment
-Requirements Class.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/railway"/>
-    <skos:prefLabel>Requirement: /req/railway/alignment</skos:prefLabel>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes"/>
     <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <skos:definition>Verify that the encoding specifies which of the FacilityPart subtypes shown in Figure 10 it supports.</skos:definition>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-feature/classes">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>The LandFeature Requirements Class Classes shown in blue in Figure 55 shall be provided for by the encoding in a manner consistent with the encoding.</dct:description>
-    <skos:definition>The LandFeature Requirements Class Classes shown in blue in Figure 55 shall be provided for by the encoding in a manner consistent with the encoding.</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature"/>
-    <skos:prefLabel>Requirement: /req/land-feature/classes</skos:prefLabel>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/land-division/classes">
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-division/classes"/>
+    <skos:prefLabel>ConformanceTest: http://www.opengis.net/spec/landinfra/1.0/conf/land-division/classes</skos:prefLabel>
     <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/def/status/superseded">
-    <na:status rdf:resource="http://www.opengis.net/def/status/stable"/>
-    <owl:sameAs rdf:resource="http://purl.org/linked-data/registry#statusSuperceded"/>
-    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
+    <skos:definition>Verify that the encoding provides the LandDivision Requirements Class Classes shown in blue in Figure 60 in a manner consistent with the encoding.</skos:definition>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
-    <skos:definition xml:lang="en">An entry that has been replaced by a new alternative which should be used instead.  Corresponds to ISO 19135:2005 'superseded'.</skos:definition>
-    <skos:altlabel xml:lang="en">replaced</skos:altlabel>
-    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
-    <skos:broader rdf:resource="http://www.opengis.net/def/status/deprecated"/>
-    <skos:prefLabel xml:lang="en">superseded</skos:prefLabel>
-    <dct:source rdf:resource="https://def.isotc211.org/iso19135/-1/2015/catalog-v001.xml"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-extensions">
-    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <dct:description>If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall specify which of the OGC Abstract Specification Topic 19, Linear Referencing extension packages it supports and shall therefore support the appropriate Classes shown in Figure 7 and Figure 8 for those packages that are appropriate to the supported subject area(s).</dct:description>
-    <skos:definition>If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall specify which of the OGC Abstract Specification Topic 19, Linear Referencing extension packages it supports and shall therefore support the appropriate Classes shown in Figure 7 and Figure 8 for those packages that are appropriate to the supported subject area(s).</skos:definition>
-    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
-    <skos:prefLabel>Requirement: /req/land-infra/topic-19-extensions</skos:prefLabel>
-    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/land-division"/>
+    <spec:purpose>Verify that the encoding provides the LandDivision Requirements Class Classes shown in blue in Figure 60 in a manner consistent with the encoding.</spec:purpose>
     <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.opengis.net/spec/docs/15-111r1-anno">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://www.ogc.org">
-    <ns2:url rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://www.ogc.org</ns2:url>
-    <rdf:type rdf:resource="https://schema.org/Organization"/>
-    <ns2:name>Open Geospatial Consortium</ns2:name>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/conf/facility/classes">
+    <spec:purpose>Verify that the encoding provides the Facility Requirements class Classes shown in blue in Figure 10 in a manner consistent with the encoding.</spec:purpose>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <spec:requirement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility/classes"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:prefLabel>Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/facility/classes</skos:prefLabel>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/facility"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/ConformanceTest"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <spec:testType rdf:resource="http://www.opengis.net/def/ont/modspec/Capabilities"/>
+    <spec:method>Inspect the encoding to verify the above requirement.</spec:method>
+    <skos:definition>Verify that the encoding provides the Facility Requirements class Classes shown in blue in Figure 10 in a manner consistent with the encoding.</skos:definition>
   </rdf:Description>
-  <rdf:Description rdf:about="http://purl.org/dc/terms/hasPart">
-    <skos:prefLabel>Has Part</skos:prefLabel>
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-infra/featureID">
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-infra"/>
+    <skos:prefLabel>Requirement: /req/land-infra/featureID</skos:prefLabel>
+    <skos:definition>An encoding shall specify if it supports ID at the feature level, ID at the Feature sub-type level, or both.</skos:definition>
+    <dct:description>An encoding shall specify if it supports ID at the feature level, ID at the Feature sub-type level, or both.</dct:description>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/linked-data/registry#Register">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <skos:prefLabel>Governed Artefact</skos:prefLabel>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/road/classes">
+    <skos:definition>The Road Requirements Class Classes shown in blue in Figure 21 shall be
+provided for by the encoding in a manner consistent with the encoding.</skos:definition>
+    <skos:prefLabel>Requirement: /req/road/classes</skos:prefLabel>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/road"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <dct:description>The Road Requirements Class Classes shown in blue in Figure 21 shall be
+provided for by the encoding in a manner consistent with the encoding.</dct:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/land-feature/alignment">
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:prefLabel>Requirement: /req/land-feature/alignment</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+    <skos:definition>If an encoding allows the linear element used for a LandLayer to be an Alignment, then that encoding shall support the Alignment Requirements Class.</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <dct:description>If an encoding allows the linear element used for a LandLayer to be an Alignment, then that encoding shall support the Alignment Requirements Class.</dct:description>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/land-feature"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/def/status/under-development">
+    <skos:prefLabel xml:lang="en">Under Development</skos:prefLabel>
+    <na:status rdf:resource="http://www.opengis.net/def/status/experimental"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/metamodel/ogc-na/Status"/>
+    <skos:broader rdf:resource="http://www.opengis.net/def/status/notAccepted"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:definition xml:lang="en">An entry that is under development, but is part of a committed roadmap, rather than experimental</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/facility/classes">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/facility"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <skos:definition>The Facility Requirements Class Classes shown in blue in Figure 10 shall be provided for by the encoding in a manner consistent with the encoding.</skos:definition>
+    <skos:prefLabel>Requirement: /req/facility/classes</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <dct:description>The Facility Requirements Class Classes shown in blue in Figure 10 shall be provided for by the encoding in a manner consistent with the encoding.</dct:description>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/Requirement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/spec/landinfra/1.0/req/condominium">
+    <skos:inScheme rdf:resource="http://www.opengis.net/def/status"/>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/RequirementClass"/>
+    <skos:inScheme rdf:resource="http://www.opengis.net/spec/landinfra/1.0"/>
+    <skos:narrower rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/condominium/classes"/>
+    <skos:definition>Requirement Class: Condominium</skos:definition>
+    <skos:prefLabel>Requirement Class: Condominium</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:broader rdf:resource="http://www.opengis.net/spec/landinfra/1.0/conf/condominium"/>
+    <spec:normativeStatement rdf:resource="http://www.opengis.net/spec/landinfra/1.0/req/condominium/classes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/def/ont/modspec/CM">
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/StandardizationTargetType"/>
+    <skos:prefLabel>Conceptual Model</skos:prefLabel>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/def/ont/modspec/Basic">
+    <skos:prefLabel>Basic</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/TestType"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.opengis.net/def/ont/modspec/Capabilities">
+    <skos:prefLabel>Capabilities</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.opengis.net/def/ont/modspec/TestType"/>
   </rdf:Description>
 </rdf:RDF>

--- a/specification-elements/defs/entailed/landinfra/1.0.ttl
+++ b/specification-elements/defs/entailed/landinfra/1.0.ttl
@@ -86,24 +86,12 @@ status:under-development a na:Status,
     skos:inScheme <http://www.opengis.net/def/status> ;
     skos:prefLabel "Under Development"@en .
 
-status:reserved a na:Status,
-        skos:Concept ;
-    dct:source reg: ;
-    na:status status:stable ;
-    rdfs:isDefinedBy <http://www.opengis.net/def/status> ;
-    owl:sameAs reg:statusReserved ;
-    skos:broader status:notAccepted ;
-    skos:definition "A reserved entry allocated for some as yet undetermined future use."@en ;
-    skos:inScheme <http://www.opengis.net/def/status> ;
-    skos:prefLabel "reserved"@en .
-
 <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/CRS> a spec:ConformanceTest,
         skos:Concept ;
     spec:method "Inspect the encoding to verify the above requirement." ;
     spec:purpose "Verify that an encoding requires that all geometry/locations for Alignment2DHorSegments and Alignment2DVertSegments be specified using the Alignment2DHorizontal.crs which shall be a Cartesian local engineering reference system." ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/alignment/CRS> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
     skos:definition "Verify that an encoding requires that all geometry/locations for Alignment2DHorSegments and Alignment2DVertSegments be specified using the Alignment2DHorizontal.crs which shall be a Cartesian local engineering reference system." ;
     skos:inScheme <http://www.opengis.net/def/status>,
         <http://www.opengis.net/spec/landinfra/1.0> ;
@@ -115,7 +103,6 @@ status:reserved a na:Status,
     spec:purpose "Verify that the encoding implements the OGC Abstract Specification Topic 19 ILinearElement and ISpatial interfaces in a manner consistent with the encoding." ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/alignment/LR-interfaces> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
     skos:definition "Verify that the encoding implements the OGC Abstract Specification Topic 19 ILinearElement and ISpatial interfaces in a manner consistent with the encoding." ;
     skos:inScheme <http://www.opengis.net/def/status>,
         <http://www.opengis.net/spec/landinfra/1.0> ;
@@ -127,7 +114,6 @@ status:reserved a na:Status,
     spec:purpose "If an encoding includes Alignments, then verify that the encoding provides the Alignment Requirements Class Classes shown in blue in Figure 15 in a manner consistent with the encoding." ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/alignment/classes> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
     skos:definition "If an encoding includes Alignments, then verify that the encoding provides the Alignment Requirements Class Classes shown in blue in Figure 15 in a manner consistent with the encoding." ;
     skos:inScheme <http://www.opengis.net/def/status>,
         <http://www.opengis.net/spec/landinfra/1.0> ;
@@ -139,7 +125,6 @@ status:reserved a na:Status,
     spec:purpose "Verify that an encoding which includes Alignments shall specify that all of the included Alignments shall be continuous, non-overlapping, and non-branching (though it may contain intersections with other Alignments) and that if it is used within the context of a Project, the included Alignment shall be for a single alternative, as specified by the ProjectPart." ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/alignment/description> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
     skos:definition "Verify that an encoding which includes Alignments shall specify that all of the included Alignments shall be continuous, non-overlapping, and non-branching (though it may contain intersections with other Alignments) and that if it is used within the context of a Project, the included Alignment shall be for a single alternative, as specified by the ProjectPart." ;
     skos:inScheme <http://www.opengis.net/def/status>,
         <http://www.opengis.net/spec/landinfra/1.0> ;
@@ -153,13 +138,37 @@ status:reserved a na:Status,
 2) If an Alignment2DHorizontal.segment list of Alignment2DHorSegments is used as a linear element, then distanceAlong and offsetLateralDistance values shall be measured in the horizontal plane, ignoring any vertical displacement of the Alignment.  OffsetVerticalDistance values shall be absolute from the horizontal plane unless an Alignment2DVertical is specified as a VerticalOffsetReferent so as to take into consideration vertical displacement of the Alignment, if present.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/alignment/measures> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
     skos:definition """If an encoding uses Alignment as a linear element, verify that it specifies that:
 1) If an Alignment2DHorizontal.2DLinestringRepresentation or an Alignment3D.3DLinestringRepresentation is specified as a linear element, then distanceAlong shall be measured along the LineString and offsetLateralDistance and offsetVerticalDistance values shall be measured normal to the LineString from this DistanceAlong point.
 2) If an Alignment2DHorizontal.segment list of Alignment2DHorSegments is used as a linear element, then distanceAlong and offsetLateralDistance values shall be measured in the horizontal plane, ignoring any vertical displacement of the Alignment.  OffsetVerticalDistance values shall be absolute from the horizontal plane unless an Alignment2DVertical is specified as a VerticalOffsetReferent so as to take into consideration vertical displacement of the Alignment, if present.""" ;
     skos:inScheme <http://www.opengis.net/def/status>,
         <http://www.opengis.net/spec/landinfra/1.0> ;
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/measures" .
+
+status:reserved a na:Status,
+        skos:Concept ;
+    dct:source reg: ;
+    na:status status:stable ;
+    rdfs:isDefinedBy <http://www.opengis.net/def/status> ;
+    owl:sameAs reg:statusReserved ;
+    skos:broader status:notAccepted ;
+    skos:definition "A reserved entry allocated for some as yet undetermined future use."@en ;
+    skos:inScheme <http://www.opengis.net/def/status> ;
+    skos:prefLabel "reserved"@en .
+
+<http://www.opengis.net/spec/landinfra/1.0/conf/alignment> a spec:ConformanceClass,
+        skos:Concept ;
+    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/CRS>,
+        <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/LR-interfaces>,
+        <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/classes>,
+        <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/description>,
+        <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/measures> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
+    skos:definition "An alignment is a positioning element which provides a Linear Referencing System for locating physical elements.  The Alignment Requirements Class specifies how an alignment is defined and used." ;
+    skos:inScheme <http://www.opengis.net/def/status>,
+        <http://www.opengis.net/spec/landinfra/1.0> ;
+    skos:prefLabel "Conformance Class: Alignment" ;
+    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/alignment> .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/condominium/classes> a spec:ConformanceTest,
         skos:Concept ;
@@ -199,7 +208,6 @@ status:reserved a na:Status,
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/facility/classes> a spec:ConformanceTest,
         skos:Concept ;
-    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
     spec:method "Inspect the encoding to verify the above requirement." ;
     spec:purpose "Verify that the encoding provides the Facility Requirements class Classes shown in blue in Figure 10 in a manner consistent with the encoding." ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/facility/classes> ;
@@ -370,7 +378,6 @@ status:reserved a na:Status,
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/project/classes> a spec:ConformanceTest,
         skos:Concept ;
-    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
     spec:method "Inspect the encoding to verify the above requirement." ;
     spec:purpose "Verify that the encoding provides the Project Requirements Class Classes shown in blue in Figure 13 in a manner consistent with the encoding." ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/project/classes> ;
@@ -595,9 +602,20 @@ status:superseded a na:Status,
     skos:inScheme <http://www.opengis.net/def/status> ;
     skos:prefLabel "superseded"@en .
 
+<http://www.opengis.net/spec/landinfra/1.0/conf/condominium> a spec:ConformanceClass,
+        skos:Concept ;
+    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/condominium/classes> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-division> ;
+    skos:definition "A condominium denotes concurrent ownership of real property that has been divided into private and common portions.  The Condominium Requirements Class includes information about condominium units, buildings and schemes." ;
+    skos:inScheme <http://www.opengis.net/def/status>,
+        <http://www.opengis.net/spec/landinfra/1.0> ;
+    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/condominium/classes>,
+        <http://www.opengis.net/spec/landinfra/1.0/req/condominium> ;
+    skos:prefLabel "Conformance Class: Condominium" ;
+    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/condominium> .
+
 <http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes> a spec:ConformanceTest,
         skos:Concept ;
-    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
     spec:method "Inspect the encoding to verify the above requirement." ;
     spec:purpose "Verify that the encoding specifies which of the FacilityPart subtypes shown in Figure 10 it supports." ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/facility/subtypes> ;
@@ -608,6 +626,19 @@ status:superseded a na:Status,
         <http://www.opengis.net/spec/landinfra/1.0> ;
     skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes> ;
     skos:prefLabel "ConformanceTest: http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes" .
+
+<http://www.opengis.net/spec/landinfra/1.0/conf/land-feature> a spec:ConformanceClass,
+        skos:Concept ;
+    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment>,
+        <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/classes> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
+    skos:definition "Features of the land, such as naturally occurring water features and vegetation are specified in the LandFeature Requirements Class as land features.  Also included are models of the land surface and subsurface layers.  Improvements to the land such as the construction of an embankment or the planting of landscape material are considered to be part of Site Facilities in the Facility Requirements Class." ;
+    skos:inScheme <http://www.opengis.net/def/status>,
+        <http://www.opengis.net/spec/landinfra/1.0> ;
+    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/classes>,
+        <http://www.opengis.net/spec/landinfra/1.0/req/land-feature> ;
+    skos:prefLabel "Conformance Class: LandFeature" ;
+    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/land-feature> .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment> a spec:ConformanceTest,
         skos:Concept ;
@@ -621,6 +652,42 @@ status:superseded a na:Status,
         <http://www.opengis.net/spec/landinfra/1.0> ;
     skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment> ;
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment" .
+
+<http://www.opengis.net/spec/landinfra/1.0/conf/observations> a spec:ConformanceClass,
+        skos:Concept ;
+    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/observations/classes> ;
+    skos:definition "Observations Requirements class is the package containing all information about the raw observations and the measurements observed during survey work. The raw observations are needed to enable later reprocessing or reporting of resulting properties of the observed feature of interest." ;
+    skos:inScheme <http://www.opengis.net/def/status>,
+        <http://www.opengis.net/spec/landinfra/1.0> ;
+    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/observations/classes>,
+        <http://www.opengis.net/spec/landinfra/1.0/req/observations> ;
+    skos:prefLabel "Conformance Class: Observations" ;
+    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/observations> ;
+    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> .
+
+<http://www.opengis.net/spec/landinfra/1.0/conf/project> a spec:ConformanceClass,
+        skos:Concept ;
+    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/project/classes> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
+    skos:definition "A project is an activity related to the improvement of a facility, including design and/or construction.  This class may be for the creation, modification, or elimination of the entire facility or a part of the facility.  The Project Requirements Class includes information about projects and their decomposition into project parts.  In order to allow for the condition where none of the LandInfra dataset information is project related, this Requirements Class is optional." ;
+    skos:inScheme <http://www.opengis.net/def/status>,
+        <http://www.opengis.net/spec/landinfra/1.0> ;
+    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/project/classes>,
+        <http://www.opengis.net/spec/landinfra/1.0/req/project> ;
+    skos:prefLabel "Conformance Class: Project" ;
+    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/project> .
+
+<http://www.opengis.net/spec/landinfra/1.0/conf/survey> a spec:ConformanceClass,
+        skos:Concept ;
+    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/survey/classes> ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
+    skos:definition "The Survey Requirements Class is the main survey class and provides a framework for information about observations, processes and their results collected during survey work. The content of this package is similar to the OGC Sensor Model Language (SensorML). The main reason not to use the SensorML standard for this topic is to allow the observation and processes structured in a compact way similar to the LandXML format. Due to the high number of classes the Survey Package was split into different parts, Equipment, Observations and SurveyResults." ;
+    skos:inScheme <http://www.opengis.net/def/status>,
+        <http://www.opengis.net/spec/landinfra/1.0> ;
+    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/survey/classes>,
+        <http://www.opengis.net/spec/landinfra/1.0/req/survey> ;
+    skos:prefLabel "Conformance Class: Survey" ;
+    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/survey> .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/alignment/CRS> a spec:Requirement,
         skos:Concept ;
@@ -1001,77 +1068,72 @@ status:deprecated a na:Status,
         status:superseded ;
     skos:prefLabel "deprecated"@en .
 
-<http://www.opengis.net/spec/landinfra/1.0/conf/condominium> a spec:ConformanceClass,
+<http://www.opengis.net/spec/landinfra/1.0/conf/equipment> a spec:ConformanceClass,
         skos:Concept ;
-    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/condominium/classes> ;
-    skos:definition "Conformance Class: Condominium" ;
+    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/equipment/classes>,
+        <http://www.opengis.net/spec/landinfra/1.0/conf/equipment/observation-correction> ;
+    skos:definition "In the Equipment Requirements class all information about the processes and the sensors is available that had been used for the determination of an observation." ;
     skos:inScheme <http://www.opengis.net/def/status>,
         <http://www.opengis.net/spec/landinfra/1.0> ;
-    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/condominium/classes>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/condominium> ;
-    skos:prefLabel "Conformance Class: Condominium" ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/condominium> ;
+    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/equipment/classes>,
+        <http://www.opengis.net/spec/landinfra/1.0/conf/equipment/observation-correction>,
+        <http://www.opengis.net/spec/landinfra/1.0/req/equipment> ;
+    skos:prefLabel "Conformance Class: Equipment" ;
+    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/equipment> ;
     skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/land-division> a spec:ConformanceClass,
         skos:Concept ;
     spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/land-division/classes> ;
-    skos:definition "Conformance Class: LandDivision" ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
+    skos:definition "Land can be divided up into land divisions.  These can either be public (political, judicial, or executive) or private in nature.  The former are administrative divisions and the latter are interests in land.  Both of these are specified in the LandDivision Requirements Class, though condominium interests in land are specified in a separate, Condominium Requirements Class." ;
     skos:inScheme <http://www.opengis.net/def/status>,
         <http://www.opengis.net/spec/landinfra/1.0> ;
     skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/land-division/classes>,
         <http://www.opengis.net/spec/landinfra/1.0/req/land-division> ;
     skos:prefLabel "Conformance Class: LandDivision" ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/land-division> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> .
+    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/land-division> .
 
-<http://www.opengis.net/spec/landinfra/1.0/conf/land-feature> a spec:ConformanceClass,
+<http://www.opengis.net/spec/landinfra/1.0/conf/road> a spec:ConformanceClass,
         skos:Concept ;
-    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/classes> ;
-    skos:definition "Conformance Class: LandFeature" ;
+    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/road/alignment>,
+        <http://www.opengis.net/spec/landinfra/1.0/conf/road/classes> ;
+    skos:definition "The Road Requirements Class supports those use cases in which a designer wishes to exchange the output of the design with someone who is likely to use it for purposes other than completing the road design.  Consequently, the Road Requirements Class includes several alternative ways for representing a design such as with 3D RoadElements, 3D StringLines (aka profile views, longitudinal breaklines, long sections), and 3D surfaces and layers, as well as collections of these." ;
     skos:inScheme <http://www.opengis.net/def/status>,
         <http://www.opengis.net/spec/landinfra/1.0> ;
-    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/classes>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/land-feature> ;
-    skos:prefLabel "Conformance Class: LandFeature" ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/land-feature> ;
+    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/road/alignment>,
+        <http://www.opengis.net/spec/landinfra/1.0/conf/road/classes>,
+        <http://www.opengis.net/spec/landinfra/1.0/req/road> ;
+    skos:prefLabel "Conformance Class: Road" ;
+    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/road> ;
     skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> .
 
-<http://www.opengis.net/spec/landinfra/1.0/conf/observations> a spec:ConformanceClass,
+<http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section> a spec:ConformanceClass,
         skos:Concept ;
-    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/observations/classes> ;
-    skos:definition "Conformance Class: Observations" ;
+    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/alignment>,
+        <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/classes> ;
+    skos:definition "The RoadCrossSection Requirements Class extends the Road Requirements Class by adding the 2D CrossSection alternative way of representing a design, as well as collections of these." ;
     skos:inScheme <http://www.opengis.net/def/status>,
         <http://www.opengis.net/spec/landinfra/1.0> ;
-    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/observations/classes>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/observations> ;
-    skos:prefLabel "Conformance Class: Observations" ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/observations> ;
+    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/alignment>,
+        <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/classes>,
+        <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section> ;
+    skos:prefLabel "Conformance Class: RoadCrossSection" ;
+    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section> ;
     skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> .
 
-<http://www.opengis.net/spec/landinfra/1.0/conf/project> a spec:ConformanceClass,
+<http://www.opengis.net/spec/landinfra/1.0/conf/survey-results> a spec:ConformanceClass,
         skos:Concept ;
-    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/project/classes> ;
-    skos:definition "Conformance Class: Project" ;
+    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/classes>,
+        <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/topic-20> ;
+    skos:definition "The SurveyResults Requirements Class contains the observed property of a feature of interest.  Using sampling features from the Observation & Measurements (O&M) standard, the dependencies between the observation acts and the results are realized." ;
     skos:inScheme <http://www.opengis.net/def/status>,
         <http://www.opengis.net/spec/landinfra/1.0> ;
-    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/project/classes>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/project> ;
-    skos:prefLabel "Conformance Class: Project" ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/project> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> .
-
-<http://www.opengis.net/spec/landinfra/1.0/conf/survey> a spec:ConformanceClass,
-        skos:Concept ;
-    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/survey/classes> ;
-    skos:definition "Conformance Class: Survey" ;
-    skos:inScheme <http://www.opengis.net/def/status>,
-        <http://www.opengis.net/spec/landinfra/1.0> ;
-    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/survey/classes>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/survey> ;
-    skos:prefLabel "Conformance Class: Survey" ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/survey> ;
+    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/classes>,
+        <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/topic-20>,
+        <http://www.opengis.net/spec/landinfra/1.0/req/survey-results> ;
+    skos:prefLabel "Conformance Class: Survey Results" ;
+    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/survey-results> ;
     skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/equipment> a spec:RequirementClass,
@@ -1134,73 +1196,33 @@ status:deprecated a na:Status,
         <http://www.opengis.net/spec/landinfra/1.0/req/survey-results/topic-20> ;
     skos:prefLabel "Requirement Class: SurveyResult" .
 
-<http://www.opengis.net/spec/landinfra/1.0/conf/equipment> a spec:ConformanceClass,
-        skos:Concept ;
-    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/equipment/classes>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/equipment/observation-correction> ;
-    skos:definition "Conformance Class: Equipment" ;
-    skos:inScheme <http://www.opengis.net/def/status>,
-        <http://www.opengis.net/spec/landinfra/1.0> ;
-    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/equipment/classes>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/equipment/observation-correction>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/equipment> ;
-    skos:prefLabel "Conformance Class: Equipment" ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/equipment> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> .
-
 <http://www.opengis.net/spec/landinfra/1.0/conf/facility> a spec:ConformanceClass,
         skos:Concept ;
     spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/facility/classes>,
         <http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes> ;
-    skos:definition "Conformance Class: Facility" ;
+    spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
+    skos:definition "Facilities include collections of buildings and civil engineering works and their associated siteworks.  The Facilities Requirements Class includes the breakdown of facilities into discipline specific facility parts and introduces the notion of elements which make up these parts.  The Facilities Requirements Class only provides general support for facilities themselves, allowing subsequent Requirements Classes to focus on specific types of the parts that make up facilities, such as road and railway.  This Requirements Class is optional in order to allow for the condition where all of the LandInfra dataset information is not facility related, such as one containing only survey or land division information." ;
     skos:inScheme <http://www.opengis.net/def/status>,
         <http://www.opengis.net/spec/landinfra/1.0> ;
     skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/facility/classes>,
         <http://www.opengis.net/spec/landinfra/1.0/req/facility> ;
     skos:prefLabel "Conformance Class: Facility" ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/facility> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> .
+    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/facility> .
 
-<http://www.opengis.net/spec/landinfra/1.0/conf/road> a spec:ConformanceClass,
+<http://www.opengis.net/spec/landinfra/1.0/conf/railway> a spec:ConformanceClass,
         skos:Concept ;
-    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/road/alignment>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/road/classes> ;
-    skos:definition "Conformance Class: Road" ;
+    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/railway/alignment>,
+        <http://www.opengis.net/spec/landinfra/1.0/conf/railway/cant>,
+        <http://www.opengis.net/spec/landinfra/1.0/conf/railway/classes> ;
+    skos:definition "The Railway Requirements Class supports those use cases where a designer wishes to exchange the output of the railway design with someone who is likely to use if for purposes other than further design. Consequently, the Railway Requirements Class covers design output such as 3D railway elements and track geometry including superelevation (cant)." ;
     skos:inScheme <http://www.opengis.net/def/status>,
         <http://www.opengis.net/spec/landinfra/1.0> ;
-    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/road/alignment>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/road/classes>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/road> ;
-    skos:prefLabel "Conformance Class: Road" ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/road> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> .
-
-<http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section> a spec:ConformanceClass,
-        skos:Concept ;
-    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/alignment>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/classes> ;
-    skos:definition "Conformance Class: RoadCrossSection" ;
-    skos:inScheme <http://www.opengis.net/def/status>,
-        <http://www.opengis.net/spec/landinfra/1.0> ;
-    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/alignment>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/classes>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section> ;
-    skos:prefLabel "Conformance Class: RoadCrossSection" ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> .
-
-<http://www.opengis.net/spec/landinfra/1.0/conf/survey-results> a spec:ConformanceClass,
-        skos:Concept ;
-    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/classes>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/topic-20> ;
-    skos:definition "Conformance Class: SurveyResults" ;
-    skos:inScheme <http://www.opengis.net/def/status>,
-        <http://www.opengis.net/spec/landinfra/1.0> ;
-    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/classes>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/topic-20>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/survey-results> ;
-    skos:prefLabel "Conformance Class: SurveyResults" ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/survey-results> ;
+    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/railway/alignment>,
+        <http://www.opengis.net/spec/landinfra/1.0/conf/railway/cant>,
+        <http://www.opengis.net/spec/landinfra/1.0/conf/railway/classes>,
+        <http://www.opengis.net/spec/landinfra/1.0/req/railway> ;
+    skos:prefLabel "Conformance Class: Railway" ;
+    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/railway> ;
     skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/railway> a spec:RequirementClass,
@@ -1300,21 +1322,23 @@ status:notAccepted a na:Status,
     skos:prefLabel "not accepted"@en ;
     skos:topConceptOf <http://www.opengis.net/def/status> .
 
-<http://www.opengis.net/spec/landinfra/1.0/conf/railway> a spec:ConformanceClass,
+<http://www.opengis.net/spec/landinfra/1.0/req/alignment> a spec:RequirementClass,
         skos:Concept ;
-    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/railway/alignment>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/railway/cant>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/railway/classes> ;
-    skos:definition "Conformance Class: Railway" ;
+    spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/alignment/CRS>,
+        <http://www.opengis.net/spec/landinfra/1.0/req/alignment/LR-interfaces>,
+        <http://www.opengis.net/spec/landinfra/1.0/req/alignment/classes>,
+        <http://www.opengis.net/spec/landinfra/1.0/req/alignment/description>,
+        <http://www.opengis.net/spec/landinfra/1.0/req/alignment/measures> ;
+    skos:definition "Requirement Class: Alignment" ;
     skos:inScheme <http://www.opengis.net/def/status>,
         <http://www.opengis.net/spec/landinfra/1.0> ;
-    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/railway/alignment>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/railway/cant>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/railway/classes>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/railway> ;
-    skos:prefLabel "Conformance Class: Railway" ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/railway> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> .
+    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/req/alignment/CRS>,
+        <http://www.opengis.net/spec/landinfra/1.0/req/alignment/LR-interfaces>,
+        <http://www.opengis.net/spec/landinfra/1.0/req/alignment/classes>,
+        <http://www.opengis.net/spec/landinfra/1.0/req/alignment/description>,
+        <http://www.opengis.net/spec/landinfra/1.0/req/alignment/measures> ;
+    skos:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
+    skos:prefLabel "Requirement Class: Alignment" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/road> a spec:RequirementClass,
         skos:Concept ;
@@ -1357,44 +1381,6 @@ status:valid a na:Status,
         status:stable ;
     skos:prefLabel "valid"@en .
 
-<http://www.opengis.net/spec/landinfra/1.0/req/alignment> a spec:RequirementClass,
-        skos:Concept ;
-    spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/alignment/CRS>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/alignment/LR-interfaces>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/alignment/classes>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/alignment/description>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/alignment/measures> ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
-    skos:definition "Requirement Class: Alignment" ;
-    skos:inScheme <http://www.opengis.net/def/status>,
-        <http://www.opengis.net/spec/landinfra/1.0> ;
-    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/req/alignment/CRS>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/alignment/LR-interfaces>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/alignment/classes>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/alignment/description>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/alignment/measures> ;
-    skos:prefLabel "Requirement Class: Alignment" .
-
-<http://www.opengis.net/spec/landinfra/1.0/conf/alignment> a spec:ConformanceClass,
-        skos:Concept ;
-    spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/CRS>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/LR-interfaces>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/classes>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/description>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/measures> ;
-    skos:definition "Conformance Class: Alignment" ;
-    skos:inScheme <http://www.opengis.net/def/status>,
-        <http://www.opengis.net/spec/landinfra/1.0> ;
-    skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/CRS>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/LR-interfaces>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/classes>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/description>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/measures>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/alignment> ;
-    skos:prefLabel "Conformance Class: Alignment" ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/alignment> ;
-    skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> .
-
 <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> a spec:RequirementClass,
         skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19103>,
@@ -1407,7 +1393,7 @@ status:valid a na:Status,
         <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-1>,
         <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-core>,
         <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-extensions> ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
+    spec:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
     skos:definition "Requirement Class: LandInfra" ;
     skos:inScheme <http://www.opengis.net/def/status>,
         <http://www.opengis.net/spec/landinfra/1.0> ;
@@ -1446,7 +1432,7 @@ status:stable a na:Status,
         <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-1>,
         <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-core>,
         <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-extensions> ;
-    skos:definition "Core Conformance Class: LandInfra" ;
+    skos:definition "LandInfra is the core Requirements Class and is the only mandatory Requirements Class.  This class contains information about the Land and Infrastructure dataset that can contain information about facilities, land features, land division, documents, survey marks, surveys, sets, and feature associations.  LandInfra also contains the definition of types common across other Requirements Classes, such as the Status CodeList." ;
     skos:inScheme <http://www.opengis.net/def/status>,
         <http://www.opengis.net/spec/landinfra/1.0> ;
     skos:narrower <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19103>,
@@ -1458,8 +1444,7 @@ status:stable a na:Status,
         <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/subjects>,
         <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-1>,
         <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-core>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-extensions>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
+        <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-extensions> ;
     skos:prefLabel "Core Conformance Class: LandInfra" ;
     skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
     skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> .
@@ -1474,20 +1459,7 @@ spec:Capabilities a spec:TestType ;
     na:status status:experimental ;
     spec:status status:experimental ;
     skos:definition "A convenience hierarchy for navigating the elements of a specification using the SKOS model" ;
-    skos:hasTopConcept <http://www.opengis.net/spec/landinfra/1.0/conf/alignment>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/condominium>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/equipment>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/facility>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/land-division>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/observations>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/project>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/railway>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/road>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/survey>,
-        <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results> ;
+    skos:hasTopConcept <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
     skos:prefLabel "Specification elements for OGC 15-111r LandInfra" .
 
 <http://www.opengis.net/def/status> a skos:ConceptScheme ;


### PR DESCRIPTION
1. 15-111r1.ttl - classes have spec:dependancy based on the 7.1 from git push --set-upstream origin 15-111r1_min_spec
2. 15-111r1.ttl - classes have skos:definition based on the same chapter
3. spec_as_conceptscheme.shapes.ttl - spec:dependency produce skos:broader/narrower
4. 15-111r1.ttl - only one skos:topConcept following hierarchy produced in previous point