### PR TITLE
cleaned 15-111r1 and skos secondary rels in the entailment

### DIFF
--- a/scripts/spec_as_conceptscheme.shapes.ttl
+++ b/scripts/spec_as_conceptscheme.shapes.ttl
@@ -111,27 +111,58 @@ WHERE {
 
 :NodeShape_class_dependency
   a sh:NodeShape ;
-  sh:rule :classdependencies ;
-  rdfs:domain [
-      a owl:Class ;
-      owl:unionOf (
-          spec:RequirementsClass
-          spec:ConformanceClass
-        ) ;
-    ] ;
+  #sh:rule :specNarrower ;
+  #sh:rule :specBroader ;
+  sh:rule :inscheme ;
+  sh:targetClass skos:Concept ;
 .
 
-:classdependencies
+:specBroader
   a sh:SPARQLRule ;
   rdfs:label "Create skos:broader hierarchy for spec:dependency" ;
   sh:construct """PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-  		     prefix spec: <http://www.opengis.net/def/ont/modspec/>
-           CONSTRUCT {
-           ?c skos:broader ?this .
-           ?this skos:narrower ?c .
-           }
-           WHERE {
-               ?c spec:dependency ?this
-               FILTER NOT EXISTS { ?c skos:broader ?this } #not sure if this is most effective to query it instead of just adding second time same relation
-           }""" ;
+                  prefix spec: <http://www.opengis.net/def/ont/modspec/>
+                  CONSTRUCT {
+                    ?this skos:broader ?c .
+                    ?c skos:narrower ?this .
+                    }
+                    WHERE {
+                         ?this spec:dependency ?c
+                  }""" ;
+  sh:prefixes <http://www.w3.org/2004/02/skos/core> ;
+
+.
+
+:specNarrower
+  a sh:SPARQLRule ;
+  rdfs:label "Create skos:narrower hierarchy for modspec properties" ;
+  sh:construct """PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+                  prefix spec: <http://www.opengis.net/def/ont/modspec/>
+                  CONSTRUCT {
+                    ?this skos:narrower ?c .
+                    ?c skos:broader ?this .
+                    }
+                    WHERE {
+                        { ?this spec:requirementsTested ?c }
+                        UNION { ?this spec:requirement ?c }
+                        UNION { ?this spec:conformanceTest ?c }
+                  }""" ;
+.
+
+:inscheme
+ a sh:SPARQLRule ;
+  rdfs:label "Add inScheme if missing"@en;
+  rdfs:comment "spin rule to create and link skos:inScheme not present. Run at conceptscheme for single pass efficiency"@en ;
+  sh:construct """
+		     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+		     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+		     CONSTRUCT  {
+				 ?this skos:inScheme ?s .
+				}
+			 WHERE {
+			    ?s a skos:ConceptScheme .
+			    { ?this a skos:Concept }  UNION {?this a skos:Collection }
+			    FILTER NOT EXISTS{ ?this skos:inScheme ?cs } .
+			    }
+			""" ;
 .

--- a/specification-elements/defs/15-111r1.ttl
+++ b/specification-elements/defs/15-111r1.ttl
@@ -21,8 +21,6 @@
 .
 
 
-
-
 <http://www.opengis.net/spec/landinfra/1.0> a skos:ConceptScheme ;
   dct:source <http://www.opengis.net/def/docs/15-111r1> ;
   skos:prefLabel "Specification elements for OGC 15-111r LandInfra" ;
@@ -54,10 +52,8 @@
         <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/CRS> ,
         <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/LR-interfaces> ,
         <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/measures> ;
-    #skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/alignment> ;
-
+    spec:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/alignment> ;
     skos:definition "An alignment is a positioning element which provides a Linear Referencing System for locating physical elements.  The Alignment Requirements Class specifies how an alignment is defined and used." ;
     skos:prefLabel "Conformance Class: Alignment" .
 
@@ -68,7 +64,6 @@
     skos:definition """If an encoding includes Alignments, then verify that the encoding provides the Alignment Requirements Class Classes shown in blue in Figure 15 in a manner consistent with the encoding.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/alignment/classes> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/description> a spec:ConformanceTest,
@@ -78,8 +73,6 @@
     skos:definition """Verify that an encoding which includes Alignments shall specify that all of the included Alignments shall be continuous, non-overlapping, and non-branching (though it may contain intersections with other Alignments) and that if it is used within the context of a Project, the included Alignment shall be for a single alternative, as specified by the ProjectPart.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/alignment/description> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/description" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/CRS> a spec:ConformanceTest,
@@ -89,7 +82,6 @@
     skos:definition """Verify that an encoding requires that all geometry/locations for Alignment2DHorSegments and Alignment2DVertSegments be specified using the Alignment2DHorizontal.crs which shall be a Cartesian local engineering reference system.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/alignment/CRS> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/CRS" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/LR-interfaces> a spec:ConformanceTest,
@@ -99,7 +91,6 @@
     skos:definition """Verify that the encoding implements the OGC Abstract Specification Topic 19 ILinearElement and ISpatial interfaces in a manner consistent with the encoding.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/alignment/LR-interfaces> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/LR-interfaces" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/alignment/measures> a spec:ConformanceTest,
@@ -113,17 +104,15 @@
 2) If an Alignment2DHorizontal.segment list of Alignment2DHorSegments is used as a linear element, then distanceAlong and offsetLateralDistance values shall be measured in the horizontal plane, ignoring any vertical displacement of the Alignment.  OffsetVerticalDistance values shall be absolute from the horizontal plane unless an Alignment2DVertical is specified as a VerticalOffsetReferent so as to take into consideration vertical displacement of the Alignment, if present.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/alignment/measures> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/alignment/measures" .
 
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/condominium> a spec:ConformanceClass,
         skos:Concept ;
     spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/condominium/classes> ;
-    #skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-division> ;
     skos:definition "A condominium denotes concurrent ownership of real property that has been divided into private and common portions.  The Condominium Requirements Class includes information about condominium units, buildings and schemes." ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/condominium> ;
+    spec:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/condominium> ;
     skos:prefLabel "Conformance Class: Condominium" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/condominium/classes> a spec:ConformanceTest,
@@ -133,18 +122,16 @@
     skos:definition """Verify that the encoding provides the Condominium Requirements Class Classes shown in blue in Figure 68 in a manner consistent with the encoding.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/condominium/classes> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/condominium> ;
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/condominium/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/equipment> a spec:ConformanceClass,
         skos:Concept ;
     spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/equipment/classes> ,
         <http://www.opengis.net/spec/landinfra/1.0/conf/equipment/observation-correction> ;
-    #skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
     skos:definition "In the Equipment Requirements class all information about the processes and the sensors is available that had been used for the determination of an observation." ;
     skos:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/survey> ;
     skos:prefLabel "Conformance Class: Equipment" ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/equipment> .
+    spec:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/equipment> .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/equipment/classes> a spec:ConformanceTest,
         skos:Concept ;
@@ -153,8 +140,6 @@
     skos:definition """Verify that the encoding provides the Equipment Requirements Class Classes shown in blue in Figure 48 in a manner consistent with the encoding.  An encoding shall decide which SurveySensor types it will support and define appropriate requirements classes accordingly.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/equipment/classes> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/equipment> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/equipment/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/equipment/observation-correction> a spec:ConformanceTest,
@@ -164,8 +149,6 @@
     skos:definition """Verify that the encoding provides the ObservationCorrection Classes in blue in Figure 51 in a manner consistent with the encoding.  The encoding shall decide which correction types it will support and define appropriate requirements classes accordingly.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/equipment/observation-correction> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/equipment> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/equipment/observation-correction" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/facility/classes> a spec:ConformanceTest,
@@ -175,28 +158,22 @@
     spec:purpose """Verify that the encoding provides the Facility Requirements class Classes shown in blue in Figure 10 in a manner consistent with the encoding.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/facility/classes> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/facility/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes> a spec:ConformanceTest,
         skos:Concept ;
-    #spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
     spec:method "Inspect the encoding to verify the above requirement." ;
     spec:purpose """Verify that the encoding specifies which of the FacilityPart subtypes shown in Figure 10 it supports.""" ;
     skos:definition """Verify that the encoding specifies which of the FacilityPart subtypes shown in Figure 10 it supports.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/facility/subtypes> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
-
     skos:prefLabel "ConformanceTest: http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/land-division> a spec:ConformanceClass,
         skos:Concept ;
     spec:conformanceTest  <http://www.opengis.net/spec/landinfra/1.0/conf/land-division/classes> ;
-    # skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/land-division> ;
+    spec:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/land-division> ;
     skos:definition "Land can be divided up into land divisions.  These can either be public (political, judicial, or executive) or private in nature.  The former are administrative divisions and the latter are interests in land.  Both of these are specified in the LandDivision Requirements Class, though condominium interests in land are specified in a separate, Condominium Requirements Class." ;
     skos:prefLabel "Conformance Class: LandDivision" .
 
@@ -208,17 +185,14 @@
     skos:definition """Verify that the encoding provides the LandDivision Requirements Class Classes shown in blue in Figure 60 in a manner consistent with the encoding.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/land-division/classes> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-division> ;
-
     skos:prefLabel "ConformanceTest: http://www.opengis.net/spec/landinfra/1.0/conf/land-division/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature> a spec:ConformanceClass,
         skos:Concept ;
     spec:conformanceTest  <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/classes> ,
         <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment> ;
-    # skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/land-feature> ;
+    spec:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/land-feature> ;
     skos:definition "Features of the land, such as naturally occurring water features and vegetation are specified in the LandFeature Requirements Class as land features.  Also included are models of the land surface and subsurface layers.  Improvements to the land such as the construction of an embankment or the planting of landscape material are considered to be part of Site Facilities in the Facility Requirements Class." ;
     skos:prefLabel "Conformance Class: LandFeature" .
 
@@ -229,8 +203,6 @@
     skos:definition """Verify that the encoding provides the LandFeature Requirements Class Classes shown in blue in Figure 55 in a manner consistent with the encoding.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/land-feature/classes> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature> ;
-
     skos:prefLabel "ConformanceTest: http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment> a spec:ConformanceTest,
@@ -240,8 +212,6 @@
     skos:definition """If an encoding allows the linear element used for a LandLayer to be an Alignment, then verify that the encoding supports the Alignment Requirements class.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/land-feature/alignment> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-feature/alignment" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19103> a spec:ConformanceTest,
@@ -251,8 +221,6 @@
     skos:definition "Verify that the encoding provides the core data types specified in ISO 19103 Clause 7 and shown in pink in Figure 5 that are appropriate to the supported subject area(s)." ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19103> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19103" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19109> a spec:ConformanceTest,
@@ -262,7 +230,6 @@
     skos:definition "Verify that Features shall be supported by a Land and Infrastructure encoding in accordance with the uml:feature requirement in ISO 19109:2015 Clause 8.2.6 and shown in Figure 9, as follows:   Each instance of FeatureType shall be implemented by the encoding’s equivalent of a UML Class having a generalization association with AnyFeature and with a stereotype of <<FeatureType>>." ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19109> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
 
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/19109" .
 
@@ -273,7 +240,6 @@
     skos:definition """Verify that theencoding provides the LandInfra Requirements Class Classes shown in blue in Figure 2 in a manner consistent with the encoding.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/classes> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
 
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/classes" .
 
@@ -284,7 +250,6 @@
     skos:definition "Verify that the encoding requirement for coordinate reference systems is consistent with OGC Abstract Specification Topic 2." ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/crs> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
 
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/crs" .
 
@@ -295,8 +260,6 @@
     skos:definition """Verify that the encoding specifies a LandInfra dataset in a format appropriate for that encoding.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/dataset> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/dataset" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/featureID> a spec:ConformanceTest,
@@ -306,8 +269,6 @@
     skos:definition "Verify that the encoding specifies whether it supports ID at the feature level, ID at the Feature sub-type level, or both." ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/featureID> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/featureID" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/subjects> a spec:ConformanceTest,
@@ -317,8 +278,6 @@
     skos:definition """Verify that the encoding specifies which of the LandInfra subjects it supports.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/subjects> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/subjects" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-1> a spec:ConformanceTest,
@@ -330,8 +289,6 @@
   Verify that the encoding provides the additional geometry types not found in Topic 1, but required by a specific supported requirements class, are specified in that requirements class.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-1> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-1" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-core> a spec:ConformanceTest,
@@ -341,8 +298,6 @@
     skos:definition "Verify that, if the encoding supports linearly referenced locations, then the encoding provides the PositionExpression and related Classes specified in the OGC Abstract Specification Topic 19, core Linear Referencing (LR) Package shown in pink in Figure 7 that are appropriate to the supported subject area(s)." ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-core> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-core" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-extensions> a spec:ConformanceTest,
@@ -352,16 +307,13 @@
     skos:definition "Verify that, if the encoding supports linearly referenced locations, then the encoding specifies which of the OGC Abstract Specification Topic 19, Linear Referencing extension packages it supports and therefore supports the appropriate Classes shown in Figure 7 and Figure 8 for those packages that are appropriate to the supported subject area(s)." ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-extensions> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-extensions" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/observations> a spec:ConformanceClass,
         skos:Concept ;
     spec:conformanceTest  <http://www.opengis.net/spec/landinfra/1.0/conf/observations/classes> ;
-    #skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/survey> ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/observations> ;
+    spec:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/observations> ;
     skos:definition "Observations Requirements class is the package containing all information about the raw observations and the measurements observed during survey work. The raw observations are needed to enable later reprocessing or reporting of resulting properties of the observed feature of interest." ;
     skos:prefLabel "Conformance Class: Observations" .
 
@@ -372,20 +324,15 @@
     skos:definition """Verify that the encoding provides the Observation Requirements Class Classes shown in blue in Figure 43 in a manner consistent with the encoding.  An encoding shall decide which SurveyObservation types it will support and define appropriate requirements classes accordingly. This then would include any dependent types (example SatelliteSystemType has only to be supported if the encoding will support GNSS Observations).""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/observations/classes> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/observations> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/observations/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/project/classes> a spec:ConformanceTest,
         skos:Concept ;
-    #spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
     spec:method "Inspect the encoding to verify the above requirement." ;
     spec:purpose """Verify that the encoding provides the Project Requirements Class Classes shown in blue in Figure 13 in a manner consistent with the encoding.""" ;
     skos:definition """Verify that the encoding provides the Project Requirements Class Classes shown in blue in Figure 13 in a manner consistent with the encoding.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/project/classes> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/project> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/project/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/railway> a spec:ConformanceClass,
@@ -393,10 +340,8 @@
     spec:conformanceTest  <http://www.opengis.net/spec/landinfra/1.0/conf/railway/classes> ,
         <http://www.opengis.net/spec/landinfra/1.0/conf/railway/alignment> ,
         <http://www.opengis.net/spec/landinfra/1.0/conf/railway/cant> ;
-    #skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/railway> ;
-
+    spec:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/railway> ;
     skos:definition "The Railway Requirements Class supports those use cases where a designer wishes to exchange the output of the railway design with someone who is likely to use if for purposes other than further design. Consequently, the Railway Requirements Class covers design output such as 3D railway elements and track geometry including superelevation (cant)." ;
     skos:prefLabel "Conformance Class: Railway" .
 
@@ -407,8 +352,6 @@
     skos:definition """Verify that the encoding provides the Railway Requirements Class Classes shown in blue in Figure 36 in a manner consistent with the encoding.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/railway/classes> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/railway> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/railway/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/railway/alignment> a spec:ConformanceTest,
@@ -418,8 +361,6 @@
     skos:definition """Verify that if the encoding allows the linear element used for locating RailwayElements or CantEvents to be an Alignment, then that encoding supports the Alignment Requirements Class.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/railway/alignment> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/railway> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/railway/alignment" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/railway/cant> a spec:ConformanceTest,
@@ -429,18 +370,14 @@
     skos:definition """Verify that the encoding specifies as a requirement that each CantSpecification shall cover the entire linear element the CantSpecification is located along from the linear element’s start to its end, and that the CantSpecification shall include CantEvents at the start and end of the linear element and wherever else there is a cant break along the linear element.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/railway/cant> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/railway> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/railway/cant" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/road> a spec:ConformanceClass,
         skos:Concept ;
     spec:conformanceTest  <http://www.opengis.net/spec/landinfra/1.0/conf/road/classes> ,
         <http://www.opengis.net/spec/landinfra/1.0/conf/road/alignment> ;
-    # skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/road> ;
-
+    spec:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/road> ;
     skos:definition "The Road Requirements Class supports those use cases in which a designer wishes to exchange the output of the design with someone who is likely to use it for purposes other than completing the road design.  Consequently, the Road Requirements Class includes several alternative ways for representing a design such as with 3D RoadElements, 3D StringLines (aka profile views, longitudinal breaklines, long sections), and 3D surfaces and layers, as well as collections of these." ;
     skos:prefLabel "Conformance Class: Road" .
 
@@ -452,8 +389,6 @@
     skos:definition """Verify that the encoding provides the Road Requirements Class Classes shown in blue in Figure 21 in a manner consistent with the encoding.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/road/classes> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/road> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/road/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/road/alignment> a spec:ConformanceTest,
@@ -463,18 +398,14 @@
     skos:definition """Verify that if the encoding allows the linear element used for locating RoadElements to be an Alignment, then that encoding supports the Alignment Requirements Class.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/road/alignment> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/road> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/road/alignment" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section> a spec:ConformanceClass,
         skos:Concept ;
     spec:conformanceTest  <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/classes> ,
         <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/alignment> ;
-    # skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/road> ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section> ;
-
+    spec:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section> ;
     skos:definition "The RoadCrossSection Requirements Class extends the Road Requirements Class by adding the 2D CrossSection alternative way of representing a design, as well as collections of these." ;
     skos:prefLabel "Conformance Class: RoadCrossSection" .
 
@@ -486,8 +417,6 @@
     skos:definition """Verify that the encoding provides the RoadCrossSection Requirements Class Classes shown in blue in Figure 25 in a manner consistent with the encoding.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/classes> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/alignment> a spec:ConformanceTest,
@@ -497,17 +426,13 @@
     skos:definition """Verify that if the encoding allows the linear element used for locating CrossSections to be an Alignment, then that encoding supports the Alignment Requirements Class.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/alignment> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section/alignment" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/survey> a spec:ConformanceClass,
         skos:Concept ;
     spec:conformanceTest  <http://www.opengis.net/spec/landinfra/1.0/conf/survey/classes> ;
-    #skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/survey> ;
-
+    spec:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/survey> ;
     skos:definition "The Survey Requirements Class is the main survey class and provides a framework for information about observations, processes and their results collected during survey work. The content of this package is similar to the OGC Sensor Model Language (SensorML). The main reason not to use the SensorML standard for this topic is to allow the observation and processes structured in a compact way similar to the LandXML format. Due to the high number of classes the Survey Package was split into different parts, Equipment, Observations and SurveyResults." ;
     skos:prefLabel "Conformance Class: Survey" .
 
@@ -518,18 +443,14 @@
     skos:definition """Verify that the encoding provides the Survey Requirements Class Classes shown in blue in Figure 41 in a manner consistent with the encoding.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/survey/classes> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/survey> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/survey/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results> a spec:ConformanceClass,
         skos:Concept ;
     spec:conformanceTest  <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/classes> ,
         <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/topic-20> ;
-    #skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/survey> ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/survey-results> ;
-
+    spec:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/survey-results> ;
     skos:definition "The SurveyResults Requirements Class contains the observed property of a feature of interest.  Using sampling features from the Observation & Measurements (O&M) standard, the dependencies between the observation acts and the results are realized." ;
     skos:prefLabel "Conformance Class: Survey Results" .
 
@@ -540,8 +461,6 @@
     skos:definition """Verify that the encoding provides the SurveyResults Requirements Class Classes shown in blue in Figure 52 in a manner consistent with the encoding.  An encoding shall decide which SurveyResult types it will support and define appropriate requirements classes accordingly.""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/survey-results/classes> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/topic-20> a spec:ConformanceTest,
@@ -551,323 +470,190 @@
     skos:definition """Verify that, if the encoding supports survey results subjects, then the encoding shall support the SF_SamplingFeature and related Classes specified in the OGC Abstract Specification Topic 20, Observation and Measurements shown in Figure 54 that are appropriate to the supported subject area(s).""" ;
     spec:requirement <http://www.opengis.net/spec/landinfra/1.0/req/survey-results/topic-20> ;
     spec:testType spec:Capabilities ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results> ;
-
     skos:prefLabel "Conformance Test: http://www.opengis.net/spec/landinfra/1.0/conf/survey-results/topic-20" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/alignment/CRS> a spec:Requirement,
         skos:Concept ;
     dct:description """All geometry/locations for Alignment2DHorSegments and Alignment2DVertSegments shall be specified using the Alignment2DHorizontal.crs which shall be a Cartesian local engineering reference system.""" ;
     skos:definition """All geometry/locations for Alignment2DHorSegments and Alignment2DVertSegments shall be specified using the Alignment2DHorizontal.crs which shall be a Cartesian local engineering reference system.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/alignment> ;
     skos:prefLabel "Requirement: /req/alignment/CRS" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/alignment/LR-interfaces> a spec:Requirement,
         skos:Concept ;
-    dct:description """An encoding shall implement the OGC Abstract Specification Topic 19 ILinearElement and ISpatial interfaces in a manner consistent with the encoding.""" ;
     skos:definition """An encoding shall implement the OGC Abstract Specification Topic 19 ILinearElement and ISpatial interfaces in a manner consistent with the encoding.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/alignment> ;
     skos:prefLabel "Requirement: /req/alignment/LR-interfaces" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/alignment/classes> a spec:Requirement,
         skos:Concept ;
-    dct:description """The Alignment Requirements class Classes shown in blue in Figure 15 shall be
-provided for by any encoding which includes Alignments and then in such a
-manner as is consistent with the encoding.""" ;
     skos:definition """An encoding shall implement the OGC Abstract Specification Topic 19 ILinearElement and ISpatial interfaces in a manner consistent with the encoding.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/alignment> ;
     skos:prefLabel "Requirement: /req/alignment/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/alignment/description> a spec:Requirement,
         skos:Concept ;
-    dct:description """An encoding which includes Alignments shall specify that all of the included Alignments shall be continuous, non-overlapping, and non-branching (though it may contain intersections with other Alignments) and that if it is used within the context of a Project, the included Alignment shall be for a single alternative, as specified by the ProjectPart.""" ;
     skos:definition """An encoding which includes Alignments shall specify that all of the included Alignments shall be continuous, non-overlapping, and non-branching (though it may contain intersections with other Alignments) and that if it is used within the context of a Project, the included Alignment shall be for a single alternative, as specified by the ProjectPart.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/alignment> ;
     skos:prefLabel "Requirement: /req/alignment/description" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/alignment/measures> a spec:Requirement,
         skos:Concept ;
-    dct:description """If an Alignment2DHorizontal.2DLinestringRepresentation or an Alignment3D.3DLinestringRepresentation is specified as a linear element, then distanceAlong shall be measured along the LineString and offsetLateralDistance and offsetVerticalDistance values shall be measured normal to the LineString from this DistanceAlong point. If an Alignment2DHorizontal.segment list of Alignment2DHorSegments is used as a linear element, then distanceAlong and offsetLateralDistance values shall be measured in the horizontal plane, ignoring any vertical displacement of the Alignment. OffsetVerticalDistance values shall be absolute from the horizontal plane unless an Alignment2DVertical is specified as a VerticalOffsetReferent so as to take into consideration vertical displacement of the Alignment, if present.""" ;
     skos:definition """If an Alignment2DHorizontal.2DLinestringRepresentation or an Alignment3D.3DLinestringRepresentation is specified as a linear element, then distanceAlong shall be measured along the LineString and offsetLateralDistance and offsetVerticalDistance values shall be measured normal to the LineString from this DistanceAlong point. If an Alignment2DHorizontal.segment list of Alignment2DHorSegments is used as a linear element, then distanceAlong and offsetLateralDistance values shall be measured in the horizontal plane, ignoring any vertical displacement of the Alignment. OffsetVerticalDistance values shall be absolute from the horizontal plane unless an Alignment2DVertical is specified as a VerticalOffsetReferent so as to take into consideration vertical displacement of the Alignment, if present.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/alignment> ;
     skos:prefLabel "Requirement: /req/alignment/measures" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/condominium> a spec:RequirementClass,
         skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/condominium/classes> ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/condominium> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/land-division> ;
     skos:definition "A condominium denotes concurrent ownership of real property that has been divided into private and common portions.  The Condominium Requirements Class includes information about condominium units, buildings and schemes." ;
     skos:prefLabel "Requirement Class: Condominium" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/condominium/classes> a spec:Requirement,
         skos:Concept ;
-    dct:description "The Condominium Requirements Class Classes shown in blue in Figure 68 shall be provided for by the encoding in a manner consistent with the encoding." ;
     skos:definition """The Condominium Requirements Class Classes shown in blue in Figure 68 shall be provided for by the encoding in a manner consistent with the encoding.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/condominium> ;
     skos:prefLabel "Requirement: /req/condominium/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/equipment/classes> a spec:Requirement,
         skos:Concept ;
-    dct:description """The Equipment Requirements Class Classes shown in blue in Figure 48 shall be provided for by the encoding in a manner consistent with the encoding. An encoding shall decide which SurveySensor types it will support and define appropriate requirements classes accordingly.""" ;
     skos:definition """The Equipment Requirements Class Classes shown in blue in Figure 48 shall be provided for by the encoding in a manner consistent with the encoding. An encoding shall decide which SurveySensor types it will support and define appropriate requirements classes accordingly.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/equipment> ;
     skos:prefLabel "Requirement: /req/equipment/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/equipment/observation-correction> a spec:Requirement,
         skos:Concept ;
-    dct:description """The ObservationCorrection Classes in blue in Figure 51 shall be provided for by the encoding in a manner consistent with the encoding. The encoding shall decide which correction types it will support and define appropriate requirements classes accordingly.""" ;
     skos:definition """The ObservationCorrection Classes in blue in Figure 51 shall be provided for by the encoding in a manner consistent with the encoding. The encoding shall decide which correction types it will support and define appropriate requirements classes accordingly.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/equipment> ;
     skos:prefLabel "Requirement: /req/equipment/observation-correction" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/facility/classes> a spec:Requirement,
         skos:Concept ;
-    dct:description """The Facility Requirements Class Classes shown in blue in Figure 10 shall be provided for by the encoding in a manner consistent with the encoding.""" ;
     skos:definition """The Facility Requirements Class Classes shown in blue in Figure 10 shall be provided for by the encoding in a manner consistent with the encoding.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/facility> ;
     skos:prefLabel "Requirement: /req/facility/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/facility/subtypes> a spec:Requirement,
         skos:Concept ;
-    dct:description """A Land and Infrastructure encoding shall specify which of the FacilityPart subtypes shown in Figure 10 it supports.""" ;
     skos:definition """A Land and Infrastructure encoding shall specify which of the FacilityPart subtypes shown in Figure 10 it supports.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/facility> ;
     skos:prefLabel "Requirement: /req/facility/subtypes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/land-division> a spec:RequirementClass,
         skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/land-division/classes> ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-division> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
     skos:definition "Land can be divided up into land divisions.  These can either be public (political, judicial, or executive) or private in nature.  The former are administrative divisions and the latter are interests in land.  Both of these are specified in the LandDivision Requirements Class, though condominium interests in land are specified in a separate, Condominium Requirements Class." ;
     skos:prefLabel "Requirement Class: LandVision" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/land-division/classes> a spec:Requirement,
         skos:Concept ;
-    dct:description "The LandDivision Requirements Class Classes shown in blue in Figure 60 shall be provided for by the encoding in a manner consistent with the encoding." ;
     skos:definition """The LandDivision Requirements Class Classes shown in blue in Figure 60 shall be provided for by the encoding in a manner consistent with the encoding.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/land-division> ;
     skos:prefLabel "Requirement: /req/land-division/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/land-feature/alignment> a spec:Requirement,
         skos:Concept ;
-    dct:description """If an encoding allows the linear element used for a LandLayer to be an Alignment, then that encoding shall support the Alignment Requirements Class.""" ;
     skos:definition """If an encoding allows the linear element used for a LandLayer to be an Alignment, then that encoding shall support the Alignment Requirements Class.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/land-feature> ;
     skos:prefLabel "Requirement: /req/land-feature/alignment" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/land-feature/classes> a spec:Requirement,
         skos:Concept ;
-    dct:description """The LandFeature Requirements Class Classes shown in blue in Figure 55 shall be provided for by the encoding in a manner consistent with the encoding.""" ;
     skos:definition """The LandFeature Requirements Class Classes shown in blue in Figure 55 shall be provided for by the encoding in a manner consistent with the encoding.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/land-feature> ;
     skos:prefLabel "Requirement: /req/land-feature/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19103> a spec:Requirement,
         skos:Concept ;
-    dct:description """A Land and Infrastructure encoding shall support the core data types specified in ISO 19103 Clause 7 and shown in pink in Figure 5 that are appropriate to the supported subject area(s).""" ;
     skos:definition """A Land and Infrastructure encoding shall support the core data types specified in ISO 19103 Clause 7 and shown in pink in Figure 5 that are appropriate to the supported subject area(s).""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
     skos:prefLabel "Requirement: /req/land-infra/19103" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/19109> a spec:Requirement,
         skos:Concept ;
-    dct:description """Features shall be supported by a Land and Infrastructure encoding in accordance with the uml:feature requirement in ISO 19109:2015 Clause 8.2.6 and shown in Figure 9, as follows: Each instance of FeatureType shall be implemented by the encoding’s equivalent of a UML Class having a generalization association with AnyFeature and with a stereotype of <>.""" ;
     skos:definition """Features shall be supported by a Land and Infrastructure encoding in accordance with the uml:feature requirement in ISO 19109:2015 Clause 8.2.6 and shown in Figure 9, as follows: Each instance of FeatureType shall be implemented by the encoding’s equivalent of a UML Class having a generalization association with AnyFeature and with a stereotype of <>.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
     skos:prefLabel "Requirement: /req/land-infra/19109" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/classes> a spec:Requirement,
         skos:Concept ;
-    dct:description """The LandInfra Requirements Class Classes shown in blue in Figure 2 shall be provided by the encoding in a manner consistent with the encoding.""" ;
     skos:definition """The LandInfra Requirements Class Classes shown in blue in Figure 2 shall be provided by the encoding in a manner consistent with the encoding.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
     skos:prefLabel "Requirement: /req/land-infra/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/crs> a spec:Requirement,
         skos:Concept ;
-    dct:description """An encoding shall support coordinate reference systems in accordance with OGC Abstract Specification Topic 2, Spatial Referencing by Coordinates.""" ;
     skos:definition """An encoding shall support coordinate reference systems in accordance with OGC Abstract Specification Topic 2, Spatial Referencing by Coordinates.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
     skos:prefLabel "Requirement: /req/land-infra/crs" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/dataset> a spec:Requirement,
         skos:Concept ;
-    dct:description """A Land and Infrastructure encoding shall specify a LandInfra dataset in whatever format that is appropriate to that encoding (e.g., an XML document for a GML encoding).""" ;
     skos:definition """A Land and Infrastructure encoding shall specify a LandInfra dataset in whatever format that is appropriate to that encoding (e.g., an XML document for a GML encoding).""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
     skos:prefLabel "Requirement: /req/land-infra/dataset" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/featureID> a spec:Requirement,
         skos:Concept ;
-    dct:description """An encoding shall specify if it supports ID at the feature level, ID at the Feature sub-type level, or both.""" ;
     skos:definition """An encoding shall specify if it supports ID at the feature level, ID at the Feature sub-type level, or both.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
     skos:prefLabel "Requirement: /req/land-infra/featureID" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/subjects> a spec:Requirement,
         skos:Concept ;
-    dct:description """A Land and Infrastructure encoding shall specify which of the LandInfra subjects it supports: Facility, LandFeature, LandDivision, and Survey.""" ;
     skos:definition """A Land and Infrastructure encoding shall specify which of the LandInfra subjects it supports: Facility, LandFeature, LandDivision, and Survey.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
     skos:prefLabel "Requirement: /req/land-infra/subjects" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-1> a spec:Requirement,
         skos:Concept ;
-    dct:description """A Land and Infrastructure encoding shall support the geometry types specified in the OGC Abstract Specification Topic 1, Feature Geometry as shown in pink and the SimpleTriangle, TIN, and PolyfaceMesh extensions shown in beige in Figure 6, that are appropriate to the supported subject area(s). Additional geometry types, not found in Topic 1, but required by a specific requirements class, are specified in that requirements class. If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall support the PositionExpression and related Classes specified in the OGC Abstract Specification Topic 19, core Linear Referencing (LR) Package shown in pink in Figure 7 that are appropriate to the supported subject area(s). If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall specify which of the OGC Abstract Specification Topic 19, Linear Referencing extension packages it supports and shall therefore support the appropriate Classes shown in Figure 7 and Figure 8 for those packages that are appropriate to the supported subject area(s).""" ;
     skos:definition """A Land and Infrastructure encoding shall support the geometry types specified in the OGC Abstract Specification Topic 1, Feature Geometry as shown in pink and the SimpleTriangle, TIN, and PolyfaceMesh extensions shown in beige in Figure 6, that are appropriate to the supported subject area(s). Additional geometry types, not found in Topic 1, but required by a specific requirements class, are specified in that requirements class. If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall support the PositionExpression and related Classes specified in the OGC Abstract Specification Topic 19, core Linear Referencing (LR) Package shown in pink in Figure 7 that are appropriate to the supported subject area(s). If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall specify which of the OGC Abstract Specification Topic 19, Linear Referencing extension packages it supports and shall therefore support the appropriate Classes shown in Figure 7 and Figure 8 for those packages that are appropriate to the supported subject area(s).""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
     skos:prefLabel "Requirement: /req/land-infra/topic-1" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-core> a spec:Requirement,
         skos:Concept ;
-    dct:description """If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall support the PositionExpression and related Classes specified in the OGC Abstract Specification Topic 19, core Linear Referencing (LR) Package shown in pink in Figure 7 that are appropriate to the supported subject area(s).""" ;
     skos:definition """If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall support the PositionExpression and related Classes specified in the OGC Abstract Specification Topic 19, core Linear Referencing (LR) Package shown in pink in Figure 7 that are appropriate to the supported subject area(s).""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
     skos:prefLabel "Requirement: /req/land-infra/topic-19-core" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-extensions> a spec:Requirement,
         skos:Concept ;
-    dct:description """If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall specify which of the OGC Abstract Specification Topic 19, Linear Referencing extension packages it supports and shall therefore support the appropriate Classes shown in Figure 7 and Figure 8 for those packages that are appropriate to the supported subject area(s).""" ;
     skos:definition """If a Land and Infrastructure encoding supports linearly referenced locations, then the encoding shall specify which of the OGC Abstract Specification Topic 19, Linear Referencing extension packages it supports and shall therefore support the appropriate Classes shown in Figure 7 and Figure 8 for those packages that are appropriate to the supported subject area(s).""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
     skos:prefLabel "Requirement: /req/land-infra/topic-19-extensions" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/observations> a spec:RequirementClass,
         skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/observations/classes> ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/observations> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/survey> ;
     skos:definition "Observations Requirements class is the package containing all information about the raw observations and the measurements observed during survey work. The raw observations are needed to enable later reprocessing or reporting of resulting properties of the observed feature of interest." ;
     skos:prefLabel "Requirement Class: Observations" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/observations/classes> a spec:Requirement,
         skos:Concept ;
-    dct:description """The Observations Requirements Class Classes shown in blue in Figure 41Figure
-43 shall be provided for by the encoding in a manner consistent with the
-encoding. An encoding shall decide which SurveyObservation types it will
-support and define appropriate requirements classes accordingly. This then
-would include any dependent types (example SatelliteSystemType has only to be
-supported if the encoding will support GNSS Observations).""" ;
-    skos:definition """The Observations Requirements Class Classes shown in blue in Figure 41Figure
-43 shall be provided for by the encoding in a manner consistent with the
-encoding. An encoding shall decide which SurveyObservation types it will
-support and define appropriate requirements classes accordingly. This then
-would include any dependent types (example SatelliteSystemType has only to be
-supported if the encoding will support GNSS Observations).""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/observations> ;
+    skos:definition """The Observations Requirements Class Classes shown in blue in Figure 41Figure 43 shall be provided for by the encoding in a manner consistent with the encoding. An encoding shall decide which SurveyObservation types it will support and define appropriate requirements classes accordingly. This then would include any dependent types (example SatelliteSystemType has only to be supported if the encoding will support GNSS Observations).""" ;
     skos:prefLabel "Requirement: /req/observations/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/project/classes> a spec:Requirement,
         skos:Concept ;
-    dct:description "The Project Requirements Class Classes shown in blue in Figure 13 shall be provided for by the encoding in a manner consistent with the encoding." ;
     skos:definition """The Project Requirements Class Classes shown in blue in Figure 13 shall be provided for by the encoding in a manner consistent with the encoding.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/project> ;
     skos:prefLabel "Requirement: /req/project/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/railway/alignment> a spec:Requirement,
         skos:Concept ;
-    dct:description """If an encoding allows the linear element used for locating RailwayElements or
-CantEvents to be an Alignment, then that encoding shall support the Alignment
-Requirements Class.""" ;
-    skos:definition """If an encoding allows the linear element used for locating RailwayElements or
-CantEvents to be an Alignment, then that encoding shall support the Alignment
-Requirements Class.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/railway> ;
+    skos:definition """If an encoding allows the linear element used for locating RailwayElements or CantEvents to be an Alignment, then that encoding shall support the Alignment Requirements Class.""" ;
     skos:prefLabel "Requirement: /req/railway/alignment" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/railway/cant> a spec:Requirement,
         skos:Concept ;
-    dct:description """An encoding shall specify as a requirement that each CantSpecification shall
-cover the entire linear element the CantSpecification is located along from
-the linear element’s start to its end, and that the CantSpecification shall
-include CantEvents at the start and end of the linear element and wherever
-else there is a cant break along the linear element.""" ;
-    skos:definition """An encoding shall specify as a requirement that each CantSpecification shall
-cover the entire linear element the CantSpecification is located along from
-the linear element’s start to its end, and that the CantSpecification shall
-include CantEvents at the start and end of the linear element and wherever
-else there is a cant break along the linear element.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/railway> ;
+    skos:definition """An encoding shall specify as a requirement that each CantSpecification shall cover the entire linear element the CantSpecification is located along from the linear element’s start to its end, and that the CantSpecification shall include CantEvents at the start and end of the linear element and wherever else there is a cant break along the linear element.""" ;
     skos:prefLabel "Requirement: /req/railway/cant" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/railway/classes> a spec:Requirement,
         skos:Concept ;
-    dct:description """The Railway Requirements Class Classes shown in blue in Figure 36 shall be
-provided for by the encoding in a manner consistent with the encoding.""" ;
-    skos:definition """The Railway Requirements Class Classes shown in blue in Figure 36 shall be
-provided for by the encoding in a manner consistent with the encoding.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/railway> ;
+    skos:definition """The Railway Requirements Class Classes shown in blue in Figure 36 shall be provided for by the encoding in a manner consistent with the encoding.""" ;
     skos:prefLabel "Requirement: /req/railway/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/road/alignment> a spec:Requirement,
         skos:Concept ;
-    dct:description """If an encoding allows the linear element used for locating RoadElements to be
-an Alignment, then that encoding shall support the Alignment Requirements
-Class.""" ;
-    skos:definition """If an encoding allows the linear element used for locating RoadElements to be
-an Alignment, then that encoding shall support the Alignment Requirements
-Class.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/road> ;
+    skos:definition """If an encoding allows the linear element used for locating RoadElements to be an Alignment, then that encoding shall support the Alignment Requirements Class.""" ;
     skos:prefLabel "Requirement: /req/road/alignment" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/road/classes> a spec:Requirement,
         skos:Concept ;
-    dct:description """The Road Requirements Class Classes shown in blue in Figure 21 shall be
-provided for by the encoding in a manner consistent with the encoding.""" ;
-    skos:definition """The Road Requirements Class Classes shown in blue in Figure 21 shall be
-provided for by the encoding in a manner consistent with the encoding.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/road> ;
+    skos:definition """The Road Requirements Class Classes shown in blue in Figure 21 shall be provided for by the encoding in a manner consistent with the encoding.""" ;
     skos:prefLabel "Requirement: /req/road/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/survey/classes> a spec:Requirement,
         skos:Concept ;
-    dct:description """The Survey Requirements Class Classes shown in blue in Figure 41 shall be
-provided for by the encoding in a manner consistent with the encoding.""" ;
-    skos:definition """The Survey Requirements Class Classes shown in blue in Figure 41 shall be
-provided for by the encoding in a manner consistent with the encoding.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/survey> ;
+    skos:definition """The Survey Requirements Class Classes shown in blue in Figure 41 shall be provided for by the encoding in a manner consistent with the encoding.""" ;
     skos:prefLabel "Requirement: /req/survey/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/conf/project> a spec:ConformanceClass,
         skos:Concept ;
     spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/project/classes> ;
-    #skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/project> ;
-
+    spec:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/project> ;
     skos:definition "A project is an activity related to the improvement of a facility, including design and/or construction.  This class may be for the creation, modification, or elimination of the entire facility or a part of the facility.  The Project Requirements Class includes information about projects and their decomposition into project parts.  In order to allow for the condition where none of the LandInfra dataset information is project related, this Requirements Class is optional." ;
     skos:prefLabel "Conformance Class: Project" .
 
@@ -875,8 +661,6 @@ provided for by the encoding in a manner consistent with the encoding.""" ;
         skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/equipment/classes>,
         <http://www.opengis.net/spec/landinfra/1.0/req/equipment/observation-correction> ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/equipment> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/survey> ;
     skos:definition "In the Equipment Requirements class all information about the processes and the sensors is available that had been used for the determination of an observation." ;
     skos:prefLabel "Requirement Class: Equipment" .
@@ -885,8 +669,6 @@ provided for by the encoding in a manner consistent with the encoding.""" ;
         skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/land-feature/alignment>,
         <http://www.opengis.net/spec/landinfra/1.0/req/land-feature/classes> ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-feature> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
     skos:definition "Features of the land, such as naturally occurring water features and vegetation are specified in the LandFeature Requirements Class as land features.  Also included are models of the land surface and subsurface layers.  Improvements to the land such as the construction of an embankment or the planting of landscape material are considered to be part of Site Facilities in the Facility Requirements Class." ;
     skos:prefLabel "Requirement Class: LandFeature" .
@@ -894,8 +676,6 @@ provided for by the encoding in a manner consistent with the encoding.""" ;
 <http://www.opengis.net/spec/landinfra/1.0/req/project> a spec:RequirementClass,
         skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/project/classes> ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/project> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/facility> ;
     skos:definition "Facilities include collections of buildings and civil engineering works and their associated siteworks.  The Facilities Requirements Class includes the breakdown of facilities into discipline specific facility parts and introduces the notion of elements which make up these parts.  The Facilities Requirements Class only provides general support for facilities themselves, allowing subsequent Requirements Classes to focus on specific types of the parts that make up facilities, such as road and railway.  This Requirements Class is optional in order to allow for the condition where all of the LandInfra dataset information is not facility related, such as one containing only survey or land division information." ;
     skos:prefLabel "Requirement Class: Project" .
@@ -904,69 +684,36 @@ provided for by the encoding in a manner consistent with the encoding.""" ;
         skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/alignment>,
         <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/classes> ;
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/road-cross-section> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/road> ;
     skos:definition "The RoadCrossSection Requirements Class extends the Road Requirements Class by adding the 2D CrossSection alternative way of representing a design, as well as collections of these." ;
     skos:prefLabel "Requirement Class: RoadCrossSection" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/alignment> a spec:Requirement,
         skos:Concept ;
-    dct:description """If an encoding allows the linear element used for locating CrossSections to be
-an Alignment, then that encoding shall support the Alignment Requirements
-Class.""" ;
-    skos:definition """If an encoding allows the linear element used for locating CrossSections to be
-an Alignment, then that encoding shall support the Alignment Requirements
-Class.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/road>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section> ;
+    skos:definition """If an encoding allows the linear element used for locating CrossSections to be an Alignment, then that encoding shall support the Alignment Requirements Class.""" ;
     skos:prefLabel "Requirement: /req/road-cross-section/alignment" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/classes> a spec:Requirement,
         skos:Concept ;
-    dct:description """The RoadCrossSection Requirements Class Classes shown in blue in Figure 25
-shall be provided for by the encoding in a manner consistent with the
-encoding.""" ;
-    skos:definition """The RoadCrossSection Requirements Class Classes shown in blue in Figure 25
-shall be provided for by the encoding in a manner consistent with the
-encoding.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/road>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section> ;
+    skos:definition """The RoadCrossSection Requirements Class Classes shown in blue in Figure 25 shall be provided for by the encoding in a manner consistent with the encoding.""" ;
     skos:prefLabel "Requirement: /req/road-cross-section/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/survey-results> a spec:RequirementClass,
         skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/survey-results/classes>,
         <http://www.opengis.net/spec/landinfra/1.0/req/survey-results/topic-20> ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/survey-results> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/survey> ;
     skos:definition "The SurveyResults Requirements Class contains the observed property of a feature of interest.  Using sampling features from the Observation & Measurements (O&M) standard, the dependencies between the observation acts and the results are realized." ;
     skos:prefLabel "Requirement Class: SurveyResult" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/survey-results/classes> a spec:Requirement,
         skos:Concept ;
-    dct:description """The SurveyResults Requirements Class Classes shown in blue in Figure 52 shall
-be provided for by the encoding in a manner consistent with the encoding. An
-encoding shall decide which SurveyResult types it will support and define
-appropriate requirements classes accordingly.""" ;
-    skos:definition """The SurveyResults Requirements Class Classes shown in blue in Figure 52 shall
-be provided for by the encoding in a manner consistent with the encoding. An
-encoding shall decide which SurveyResult types it will support and define
-appropriate requirements classes accordingly.""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/survey>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/survey-results> ;
+    skos:definition """The SurveyResults Requirements Class Classes shown in blue in Figure 52 shall be provided for by the encoding in a manner consistent with the encoding. An encoding shall decide which SurveyResult types it will support and define appropriate requirements classes accordingly.""" ;
     skos:prefLabel "Requirement: /req/survey-results/classes" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/survey-results/topic-20> a spec:Requirement,
         skos:Concept ;
-    dct:description "If a Land and Infrastructure encoding supports survey results subjects, then the encoding shall support the SF_SamplingFeature and related Classes specified in the OGC Abstract Specification Topic 20, Observation and Measurements shown in Figure 54 that are appropriate to the supported subject area(s)." ;
     skos:definition """If a Land and Infrastructure encoding supports survey results subjects, then the encoding shall support the SF_SamplingFeature and related Classes specified in the OGC Abstract Specification Topic 20, Observation and Measurements shown in Figure 54 that are appropriate to the supported subject area(s).""" ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/req/survey>,
-        <http://www.opengis.net/spec/landinfra/1.0/req/survey-results> ;
     skos:prefLabel "Requirement: /req/survey-results/topic-20" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/railway> a spec:RequirementClass,
@@ -974,8 +721,6 @@ appropriate requirements classes accordingly.""" ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/railway/alignment>,
         <http://www.opengis.net/spec/landinfra/1.0/req/railway/cant>,
         <http://www.opengis.net/spec/landinfra/1.0/req/railway/classes> ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/railway> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/facility> ;
     skos:definition "The Railway Requirements Class supports those use cases where a designer wishes to exchange the output of the railway design with someone who is likely to use if for purposes other than further design. Consequently, the Railway Requirements Class covers design output such as 3D railway elements and track geometry including superelevation (cant)." ;
     skos:prefLabel "Requirement Class: Railway" .
@@ -985,8 +730,6 @@ appropriate requirements classes accordingly.""" ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/survey-results/classes>,
         <http://www.opengis.net/spec/landinfra/1.0/req/survey-results/topic-20>,
         <http://www.opengis.net/spec/landinfra/1.0/req/survey/classes> ;
-
-        skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/survey> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
     skos:definition "The Survey Requirements Class is the main survey class and provides a framework for information about observations, processes and their results collected during survey work. The content of this package is similar to the OGC Sensor Model Language (SensorML). The main reason not to use the SensorML standard for this topic is to allow the observation and processes structured in a compact way similar to the LandXML format. Due to the high number of classes the Survey Package was split into different parts, Equipment, Observations and SurveyResults." ;
     skos:prefLabel "Requirement Class: Survey" .
@@ -995,9 +738,8 @@ appropriate requirements classes accordingly.""" ;
         skos:Concept ;
     spec:conformanceTest <http://www.opengis.net/spec/landinfra/1.0/conf/facility/classes>,
         <http://www.opengis.net/spec/landinfra/1.0/conf/facility/subtypes> ;
-    #skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/facility> ;
+    spec:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/facility> ;
     skos:definition "Facilities include collections of buildings and civil engineering works and their associated siteworks.  The Facilities Requirements Class includes the breakdown of facilities into discipline specific facility parts and introduces the notion of elements which make up these parts.  The Facilities Requirements Class only provides general support for facilities themselves, allowing subsequent Requirements Classes to focus on specific types of the parts that make up facilities, such as road and railway.  This Requirements Class is optional in order to allow for the condition where all of the LandInfra dataset information is not facility related, such as one containing only survey or land division information." ;
     skos:prefLabel "Conformance Class: Facility" .
 
@@ -1005,8 +747,6 @@ appropriate requirements classes accordingly.""" ;
         skos:Concept ;
     spec:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/req/facility/classes>,
         <http://www.opengis.net/spec/landinfra/1.0/req/facility/subtypes> ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/facility> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
     skos:definition "Facilities include collections of buildings and civil engineering works and their associated siteworks.  The Facilities Requirements Class includes the breakdown of facilities into discipline specific facility parts and introduces the notion of elements which make up these parts.  The Facilities Requirements Class only provides general support for facilities themselves, allowing subsequent Requirements Classes to focus on specific types of the parts that make up facilities, such as road and railway.  This Requirements Class is optional in order to allow for the condition where all of the LandInfra dataset information is not facility related, such as one containing only survey or land division information." ;
     skos:prefLabel "Requirement Class: Facility" .
@@ -1017,8 +757,6 @@ appropriate requirements classes accordingly.""" ;
         <http://www.opengis.net/spec/landinfra/1.0/req/road-cross-section/classes>,
         <http://www.opengis.net/spec/landinfra/1.0/req/road/alignment>,
         <http://www.opengis.net/spec/landinfra/1.0/req/road/classes> ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/road> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/facility> ;
     skos:definition "The Road Requirements Class supports those use cases in which a designer wishes to exchange the output of the design with someone who is likely to use it for purposes other than completing the road design.  Consequently, the Road Requirements Class includes several alternative ways for representing a design such as with 3D RoadElements, 3D StringLines (aka profile views, longitudinal breaklines, long sections), and 3D surfaces and layers, as well as collections of these. " ;
     skos:prefLabel "Requirement Class: Road" .
@@ -1030,10 +768,7 @@ appropriate requirements classes accordingly.""" ;
         <http://www.opengis.net/spec/landinfra/1.0/req/alignment/classes>,
         <http://www.opengis.net/spec/landinfra/1.0/req/alignment/description>,
         <http://www.opengis.net/spec/landinfra/1.0/req/alignment/measures> ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
     spec:dependency <http://www.opengis.net/spec/landinfra/1.0/req/facility> ;
-    skos:normativeStatement <http://www.opengis.net/spec/landinfra/1.0/conf/alignment> ;
     skos:definition "An alignment is a positioning element which provides a Linear Referencing System for locating physical elements.  The Alignment Requirements Class specifies how an alignment is defined and used." ;
     skos:prefLabel "Requirement Class: Alignment" .
 
@@ -1050,9 +785,8 @@ appropriate requirements classes accordingly.""" ;
         <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-core>,
         <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra/topic-19-extensions> ;
     skos:topConceptOf <http://www.opengis.net/spec/landinfra/1.0> ;
-    skos:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
+    spec:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> ;
     skos:definition "LandInfra is the core Requirements Class and is the only mandatory Requirements Class.  This class contains information about the Land and Infrastructure dataset that can contain information about facilities, land features, land division, documents, survey marks, surveys, sets, and feature associations.  LandInfra also contains the definition of types common across other Requirements Classes, such as the Status CodeList." ;
-
     skos:prefLabel "Core Conformance Class: LandInfra" .
 
 <http://www.opengis.net/spec/landinfra/1.0/req/land-infra> a spec:RequirementClass,
@@ -1067,10 +801,7 @@ appropriate requirements classes accordingly.""" ;
         <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-1>,
         <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-core>,
         <http://www.opengis.net/spec/landinfra/1.0/req/land-infra/topic-19-extensions> ;
-
-    skos:broader <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
     skos:definition "Requirement Class: LandInfra" ;
-    spec:requirementsTested <http://www.opengis.net/spec/landinfra/1.0/conf/land-infra> ;
     skos:prefLabel "Requirement Class: LandInfra" .
 
 <http://www.opengis.net/def/docs/15-111r1> a spec:Specification ;


### PR DESCRIPTION
Removed skos:broader, skos:narrower when they can be infered from modspec relationships.
These are generated withing spec_as_conceptscheme.ttl.

removed dct:description as it was always equal to skos:definition - only one shall be required as input, we can switch to dct:description and generate the second if needed. now skos is required for visualisation on def-server.
